### PR TITLE
✨ feat: 어드민 답변 기능 추가

### DIFF
--- a/server/.gitignore
+++ b/server/.gitignore
@@ -28,6 +28,7 @@ out/
 !**/src/main/**/out/
 !**/src/test/**/out/
 application-dev.yml
+application-test.yml
 application-local.yml
 application-debug.yml
 application-prod.yml

--- a/server/src/main/java/com/example/kakao_mlms/constant/Constants.java
+++ b/server/src/main/java/com/example/kakao_mlms/constant/Constants.java
@@ -10,5 +10,6 @@ public class Constants {
             "/api/auth/basic", "/sign-in", "/api/auth/kakao", "/oauth2/authorization/kakao",
             "/login/oauth2/code/kakao"
     };
+    public static final String IMAGE_FILE_PATH_LOCAL = "server/src/main/resources/images/";
 
 }

--- a/server/src/main/java/com/example/kakao_mlms/controller/AdminController.java
+++ b/server/src/main/java/com/example/kakao_mlms/controller/AdminController.java
@@ -4,6 +4,8 @@ import com.example.kakao_mlms.domain.type.Category;
 import com.example.kakao_mlms.dto.response.QnaDtoResponse;
 import com.example.kakao_mlms.dto.response.UserDto;
 import com.example.kakao_mlms.exception.ResponseDto;
+import com.example.kakao_mlms.security.CustomUserDetails;
+import com.example.kakao_mlms.service.AnswerService;
 import com.example.kakao_mlms.service.QnaService;
 import com.example.kakao_mlms.service.UserService;
 import lombok.RequiredArgsConstructor;
@@ -11,11 +13,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
-import org.springframework.util.StringUtils;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1/admins")
@@ -23,6 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AdminController {
     private final UserService userService;
     private final QnaService qnaService;
+    private final AnswerService answerService;
 
     @GetMapping("/users")
     public ResponseDto<Page<UserDto>> getAllUsers(
@@ -42,4 +42,13 @@ public class AdminController {
         return ResponseDto.ok(qnaResponse);
     }
 
+    @PostMapping("/qnas/{id}")
+    public ResponseDto<Long> replyQna(
+            @PathVariable Long id,
+            String content,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
+            ) {
+        answerService.replyQna(customUserDetails.getId(), id, content);
+        return ResponseDto.created(id);
+    }
 }

--- a/server/src/main/java/com/example/kakao_mlms/controller/AdminController.java
+++ b/server/src/main/java/com/example/kakao_mlms/controller/AdminController.java
@@ -1,7 +1,7 @@
 package com.example.kakao_mlms.controller;
 
 import com.example.kakao_mlms.domain.type.Category;
-import com.example.kakao_mlms.dto.QnaDtoWithImages;
+import com.example.kakao_mlms.dto.response.QnaDtoResponse;
 import com.example.kakao_mlms.dto.response.UserDto;
 import com.example.kakao_mlms.exception.ResponseDto;
 import com.example.kakao_mlms.service.QnaService;
@@ -33,11 +33,13 @@ public class AdminController {
     }
 
     @GetMapping("/qnas")
-    public ResponseDto<Page<QnaDtoWithImages>> getAllQnas(
+    public ResponseDto<Page<QnaDtoResponse>> getAllQnas(
             @RequestParam(required = false) String title,
             @RequestParam(required = false) Category Category,
             @PageableDefault(size = 10, sort = "id", direction = Sort.Direction.ASC) Pageable pageable) {
-        Page<QnaDtoWithImages> qnaDtoWithImages = qnaService.searchQnas(title, Category, pageable);
-        return ResponseDto.ok(qnaDtoWithImages);
+        Page<QnaDtoResponse> qnaResponse = qnaService.searchQnas(title, Category, pageable)
+                .map(QnaDtoResponse::from);
+        return ResponseDto.ok(qnaResponse);
     }
+
 }

--- a/server/src/main/java/com/example/kakao_mlms/dto/QnaDtoWithImages.java
+++ b/server/src/main/java/com/example/kakao_mlms/dto/QnaDtoWithImages.java
@@ -32,4 +32,8 @@ public record QnaDtoWithImages(
             qna.getImages().stream().map(ImageDto::from).toList()
     );
   }
+
+  public static QnaDtoWithImages of() {
+    return new QnaDtoWithImages(1L, null, null, null, null, null, null, null);
+  }
 }

--- a/server/src/main/java/com/example/kakao_mlms/dto/response/ImageResponse.java
+++ b/server/src/main/java/com/example/kakao_mlms/dto/response/ImageResponse.java
@@ -1,0 +1,38 @@
+package com.example.kakao_mlms.dto.response;
+
+import com.example.kakao_mlms.constant.Constants;
+import com.example.kakao_mlms.domain.type.Extension;
+import com.example.kakao_mlms.dto.ImageDto;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.Base64;
+
+@Slf4j
+public record ImageResponse(
+        String originName,
+        Extension extension,
+        String encodedImage
+) {
+    public static ImageResponse from(ImageDto imageDto) {
+        return new ImageResponse(
+                imageDto.originName(),
+                imageDto.extension(),
+                readAndEncodeImage(imageDto)
+        );
+    }
+
+    private static String readAndEncodeImage(ImageDto imageDto) {
+        String imagePath = Constants.IMAGE_FILE_PATH_LOCAL + imageDto.uuidName() + imageDto.extension();
+        File file = new File(imagePath);
+        try (FileInputStream inputStream = new FileInputStream(file)) {
+            byte[] bytes = inputStream.readAllBytes();
+            return Base64.getEncoder().encodeToString(bytes);
+        } catch (IOException e) {
+            log.error("image file read error : {}", e.getMessage());
+        }
+        return null;
+    }
+}

--- a/server/src/main/java/com/example/kakao_mlms/dto/response/QnaDtoResponse.java
+++ b/server/src/main/java/com/example/kakao_mlms/dto/response/QnaDtoResponse.java
@@ -1,0 +1,28 @@
+package com.example.kakao_mlms.dto.response;
+
+import com.example.kakao_mlms.domain.type.Category;
+import com.example.kakao_mlms.dto.QnaDtoWithImages;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record QnaDtoResponse(Long id,
+                             String content,
+                             Category category,
+                             LocalDateTime createdDate,
+                             Boolean isAnswer,
+                             Boolean isBlind,
+                             UserDto user,
+                             List<ImageResponse> images) {
+    public static QnaDtoResponse from(QnaDtoWithImages qnaDtoWithImages) {
+        return new QnaDtoResponse(qnaDtoWithImages.id(),
+                qnaDtoWithImages.content(),
+                qnaDtoWithImages.category(),
+                qnaDtoWithImages.createdDate(),
+                qnaDtoWithImages.isAnswer(),
+                qnaDtoWithImages.isBlind(),
+                qnaDtoWithImages.user(),
+                qnaDtoWithImages.images().stream()
+                        .map(ImageResponse::from).toList());
+    }
+}

--- a/server/src/main/java/com/example/kakao_mlms/dto/response/UserDto.java
+++ b/server/src/main/java/com/example/kakao_mlms/dto/response/UserDto.java
@@ -3,8 +3,8 @@ package com.example.kakao_mlms.dto.response;
 import com.example.kakao_mlms.domain.User;
 import com.example.kakao_mlms.domain.type.EProvider;
 import com.example.kakao_mlms.domain.type.ERole;
+import lombok.Builder;
 
-import java.io.Serializable;
 import java.time.LocalDate;
 
 /**
@@ -34,4 +34,9 @@ public record UserDto(
                 user.getRefreshToken()
         );
     }
+
+    public static UserDto of(String serialId, ERole role) {
+        return new UserDto(1L, serialId, null, EProvider.KAKAO, role, LocalDate.now(), null, false, null);
+    }
+
 }

--- a/server/src/main/java/com/example/kakao_mlms/intercepter/UserIdInterceptor.java
+++ b/server/src/main/java/com/example/kakao_mlms/intercepter/UserIdInterceptor.java
@@ -4,6 +4,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.servlet.HandlerInterceptor;
 @Slf4j
@@ -12,7 +13,8 @@ public class UserIdInterceptor implements HandlerInterceptor {
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
         final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         log.info("설정");
-        log.info(authentication.getName());
+        log.info(authentication.getName() + " : " + authentication.getAuthorities().stream().findFirst()
+                .map(GrantedAuthority::getAuthority).orElseThrow());
         request.setAttribute("USER_ID", authentication.getName());
 
         return HandlerInterceptor.super.preHandle(request, response, handler);

--- a/server/src/main/java/com/example/kakao_mlms/security/config/SecurityConfig.java
+++ b/server/src/main/java/com/example/kakao_mlms/security/config/SecurityConfig.java
@@ -1,20 +1,17 @@
 package com.example.kakao_mlms.security.config;
 
 import com.example.kakao_mlms.constant.Constants;
-import com.example.kakao_mlms.security.BasicAuthenticationProvider;
+import com.example.kakao_mlms.domain.type.ERole;
 import com.example.kakao_mlms.security.CustomAuthenticationProvider;
 import com.example.kakao_mlms.security.JwtAuthEntryPoint;
 import com.example.kakao_mlms.security.filter.JwtExceptionFilter;
 import com.example.kakao_mlms.security.filter.JwtFilter;
-import com.example.kakao_mlms.security.handler.*;
-import com.example.kakao_mlms.security.handler.signin.DefaultSignInFailureHandler;
-import com.example.kakao_mlms.security.handler.signin.DefaultSignInSuccessHandler;
+import com.example.kakao_mlms.security.handler.JwtAccessDeniedHandler;
 import com.example.kakao_mlms.security.handler.signin.OAuth2LoginFailureHandler;
 import com.example.kakao_mlms.security.handler.signin.OAuth2LoginSuccessHandler;
 import com.example.kakao_mlms.security.handler.signout.CustomSignOutProcessHandler;
 import com.example.kakao_mlms.security.handler.signout.CustomSignOutResultHandler;
 import com.example.kakao_mlms.security.service.CustomOAuth2UserService;
-import com.example.kakao_mlms.security.service.CustomUserDetailService;
 import com.example.kakao_mlms.util.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -26,23 +23,25 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.logout.LogoutFilter;
 
+import static org.springframework.security.config.Customizer.withDefaults;
+
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
-    private final DefaultSignInSuccessHandler defaultSignInSuccessHandler;
-    private final DefaultSignInFailureHandler defaultSignInFailureHandler;
+//    private final DefaultSignInSuccessHandler defaultSignInSuccessHandler;
+//    private final DefaultSignInFailureHandler defaultSignInFailureHandler;
+//    private final CustomUserDetailService customUserDetailService;
+//    private final BasicAuthenticationProvider basicAuthenticationProvider;
     private final JwtAuthEntryPoint jwtAuthEntryPoint;
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
     private final JwtUtil jwtUtil;
-    private final CustomUserDetailService customUserDetailService;
     private final CustomSignOutProcessHandler customSignOutProcessHandler;
     private final CustomSignOutResultHandler customSignOutResultHandler;
     private final OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
     private final OAuth2LoginFailureHandler oAuth2LoginFailureHandler;
     private final CustomOAuth2UserService customOAuth2UserService;
     private final CustomAuthenticationProvider customAuthenticationProvider;
-    private final BasicAuthenticationProvider basicAuthenticationProvider;
 
 
     @Bean
@@ -55,6 +54,7 @@ public class SecurityConfig {
                 )
                 .authorizeHttpRequests(requestMatcherRegistry -> requestMatcherRegistry
                         .requestMatchers(Constants.NO_NEED_AUTH_URLS).permitAll()
+                        .requestMatchers("/api/v1/admins/**").hasRole(ERole.ADMIN.name())
                         .anyRequest().authenticated())
                 //폼 기반 로그인 설정
 //                .formLogin(configurer ->

--- a/server/src/main/java/com/example/kakao_mlms/service/AnswerService.java
+++ b/server/src/main/java/com/example/kakao_mlms/service/AnswerService.java
@@ -1,0 +1,33 @@
+package com.example.kakao_mlms.service;
+
+import com.example.kakao_mlms.domain.Answer;
+import com.example.kakao_mlms.domain.Qna;
+import com.example.kakao_mlms.domain.User;
+import com.example.kakao_mlms.repository.AnswerRepository;
+import com.example.kakao_mlms.repository.QnaRepository;
+import com.example.kakao_mlms.repository.UserRepository;
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AnswerService {
+    private final UserRepository userRepository;
+    private final QnaRepository qnaRepository;
+    private final AnswerRepository answerRepository;
+
+
+    public void replyQna(Long adminId, Long qnaId, String content) {
+        User adminUser = userRepository.findById(adminId).orElseThrow(EntityNotFoundException::new);
+        Qna qna = qnaRepository.findById(qnaId).orElseThrow(EntityNotFoundException::new);
+
+        Answer answer = Answer.builder().content(content).qna(qna).user(adminUser).build();
+
+        answerRepository.save(answer);
+    }
+}

--- a/server/src/main/java/com/example/kakao_mlms/service/QnaService.java
+++ b/server/src/main/java/com/example/kakao_mlms/service/QnaService.java
@@ -23,7 +23,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Slf4j
 @Service

--- a/server/src/test/java/com/example/kakao_mlms/KakaoMlmsApplicationTests.java
+++ b/server/src/test/java/com/example/kakao_mlms/KakaoMlmsApplicationTests.java
@@ -2,7 +2,9 @@ package com.example.kakao_mlms;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
+@ActiveProfiles("test")
 @SpringBootTest
 class KakaoMlmsApplicationTests {
 

--- a/server/src/test/java/com/example/kakao_mlms/config/TestSecurityConfig.java
+++ b/server/src/test/java/com/example/kakao_mlms/config/TestSecurityConfig.java
@@ -1,0 +1,42 @@
+package com.example.kakao_mlms.config;
+
+import com.example.kakao_mlms.security.CustomAuthenticationProvider;
+import com.example.kakao_mlms.security.JwtAuthEntryPoint;
+import com.example.kakao_mlms.security.config.SecurityConfig;
+import com.example.kakao_mlms.security.handler.JwtAccessDeniedHandler;
+import com.example.kakao_mlms.security.handler.signin.OAuth2LoginFailureHandler;
+import com.example.kakao_mlms.security.handler.signin.OAuth2LoginSuccessHandler;
+import com.example.kakao_mlms.security.handler.signout.CustomSignOutProcessHandler;
+import com.example.kakao_mlms.security.handler.signout.CustomSignOutResultHandler;
+import com.example.kakao_mlms.security.service.CustomOAuth2UserService;
+import com.example.kakao_mlms.security.service.CustomUserDetailService;
+import com.example.kakao_mlms.util.JwtUtil;
+import jakarta.servlet.ServletException;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.event.annotation.BeforeTestMethod;
+
+import java.io.IOException;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.willDoNothing;
+
+@Import(SecurityConfig.class)
+public class TestSecurityConfig {
+
+    @MockBean private JwtAuthEntryPoint jwtAuthEntryPoint;
+    @MockBean private JwtAccessDeniedHandler jwtAccessDeniedHandler;
+    @MockBean private JwtUtil jwtUtil;
+    @MockBean private CustomSignOutProcessHandler customSignOutProcessHandler;
+    @MockBean private CustomSignOutResultHandler customSignOutResultHandler;
+    @MockBean private OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
+    @MockBean private OAuth2LoginFailureHandler oAuth2LoginFailureHandler;
+    @MockBean private CustomOAuth2UserService customOAuth2UserService;
+    @MockBean private CustomAuthenticationProvider customAuthenticationProvider;
+
+
+    @BeforeTestMethod
+    public void securitySetUp() {
+    }
+
+}

--- a/server/src/test/java/com/example/kakao_mlms/controller/AdminControllerTest.java
+++ b/server/src/test/java/com/example/kakao_mlms/controller/AdminControllerTest.java
@@ -41,12 +41,28 @@ class AdminControllerTest {
     void getAllQnas() throws Exception {
         // Given
         given(qnaService.searchQnas(eq(null), eq(null), any(Pageable.class))).willReturn(Page.empty());
+    @Test
+    void replyQna() throws Exception {
+        // Given
+        Long qnaId = 1L;
+        String content = "content";
 
         // When & Then
-        mvc.perform(get(BASE_URL + "/qnas"))
-                .andExpect(status().isUnauthorized());
-//        then(qnaService).should().searchQnas(eq(null), eq(null), any(Pageable.class));
+        mvc.perform(post(BASE_URI + "/qnas/" + qnaId)
+                .content(mapper.writeValueAsString(content))
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.data").value(qnaId));
+        then(answerService).should().replyQna(anyLong(), qnaId, content);
     }
 
+    private Page<UserDto> createUsers(String serialId, ERole role) {
+        return new PageImpl<>(List.of(UserDto.of(serialId, role)), PageRequest.of(0, 1), 1);
+    }
+
+    private Page<QnaDtoWithImages> createQnas() {
+        return new PageImpl<>(List.of(QnaDtoWithImages.of()), PageRequest.of(0, 1), 1);
+    }
 
 }

--- a/server/src/test/java/com/example/kakao_mlms/controller/AdminControllerTest.java
+++ b/server/src/test/java/com/example/kakao_mlms/controller/AdminControllerTest.java
@@ -1,46 +1,90 @@
 package com.example.kakao_mlms.controller;
 
-import com.example.kakao_mlms.KakaoMlmsApplication;
+import com.example.kakao_mlms.config.TestSecurityConfig;
+import com.example.kakao_mlms.domain.type.ERole;
+import com.example.kakao_mlms.dto.QnaDtoWithImages;
+import com.example.kakao_mlms.dto.response.UserDto;
+import com.example.kakao_mlms.service.AnswerService;
 import com.example.kakao_mlms.service.QnaService;
 import com.example.kakao_mlms.service.UserService;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+@Import(TestSecurityConfig.class)
 @WebMvcTest(AdminController.class)
 class AdminControllerTest {
 
     @Autowired private MockMvc mvc;
+    @Autowired private ObjectMapper mapper;
     @MockBean private UserService userService;
     @MockBean private QnaService qnaService;
-    private final String BASE_URL = "/api/v1/admins";
+    @MockBean private AnswerService answerService;
+    private final String BASE_URI = "/api/v1/admins";
 
+    @WithMockUser(username = "tester", roles = "ADMIN")
     @Test
-    void getAllUsers() throws Exception {
+    void getAllUsers_ByAdmin() throws Exception {
         // Given
-        given(userService.searchUsers(eq(null), any(Pageable.class))).willReturn(Page.empty());
+        given(userService.searchUsers(eq(null), any(Pageable.class)))
+                .willReturn(createUsers("tester", ERole.ADMIN));
 
         // When & Then
-        mvc.perform(get(BASE_URL + "/users"))
-                .andExpect(status().isUnauthorized());
-//        then(userService).should().searchUsers(eq(null), any(Pageable.class));
+        mvc.perform(get(BASE_URI + "/users"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON));
+        then(userService).should().searchUsers(eq(null), any(Pageable.class));
     }
 
+    @WithMockUser(username = "tester", roles = "USER")
+    @Test
+    void getAllUsers_ByUser() throws Exception {
+        // Given
+        given(userService.searchUsers(eq(null), any(Pageable.class)))
+                .willReturn(createUsers("tester", ERole.USER));
+
+        // When & Then
+        mvc.perform(get(BASE_URI + "/users"))
+                .andExpect(status().isForbidden());
+        then(userService).should().searchUsers(eq(null), any(Pageable.class));
+    }
+
+    @WithMockUser(username = "tester", roles = "ADMIN")
     @Test
     void getAllQnas() throws Exception {
         // Given
-        given(qnaService.searchQnas(eq(null), eq(null), any(Pageable.class))).willReturn(Page.empty());
+        given(qnaService.searchQnas(eq(null), eq(null), any(Pageable.class))).willReturn(createQnas());
+
+        // When & Then
+        mvc.perform(get(BASE_URI + "/qnas"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON));
+        then(qnaService).should().searchQnas(eq(null), eq(null), any(Pageable.class));
+    }
+
+//    @WithMockUser(username = "tester", roles = "ADMIN")
     @Test
     void replyQna() throws Exception {
         // Given

--- a/server/src/test/java/com/example/kakao_mlms/repository/JpaRepositoryTest.java
+++ b/server/src/test/java/com/example/kakao_mlms/repository/JpaRepositoryTest.java
@@ -7,11 +7,13 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@ActiveProfiles("test")
 @DisplayName("JPA CRUD TEST")
 @DataJpaTest()
 class JpaRepositoryTest {

--- a/server/src/test/java/com/example/kakao_mlms/service/AnswerServiceTest.java
+++ b/server/src/test/java/com/example/kakao_mlms/service/AnswerServiceTest.java
@@ -1,0 +1,53 @@
+package com.example.kakao_mlms.service;
+
+import com.example.kakao_mlms.domain.Answer;
+import com.example.kakao_mlms.domain.Qna;
+import com.example.kakao_mlms.domain.User;
+import com.example.kakao_mlms.repository.AnswerRepository;
+import com.example.kakao_mlms.repository.QnaRepository;
+import com.example.kakao_mlms.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
+class AnswerServiceTest {
+    @InjectMocks private AnswerService sut;
+    @Mock private QnaRepository qnaRepository;
+    @Mock private UserRepository userRepository;
+    @Mock private AnswerRepository answerRepository;
+
+    @Test
+    void replyQna() {
+        // Given
+        Long adminId = 1L;
+        Long qnaId = 1L;
+        given(qnaRepository.findById(qnaId)).willReturn(Optional.ofNullable(createQna()));
+        given(userRepository.findById(adminId)).willReturn(Optional.ofNullable(createUser()));
+
+        // When
+        sut.replyQna(adminId, qnaId, "content");
+
+        // Then
+        then(qnaRepository).should().findById(qnaId);
+        then(userRepository).should().findById(adminId);
+        then(answerRepository).should().save(any(Answer.class));
+    }
+
+    private Qna createQna() {
+        return Qna.builder().title("title").user(createUser()).build();
+    }
+
+    private User createUser() {
+        return User.builder().serialId("tester").build();
+    }
+
+}

--- a/server/src/test/java/com/example/kakao_mlms/service/QnaServiceTest.java
+++ b/server/src/test/java/com/example/kakao_mlms/service/QnaServiceTest.java
@@ -11,10 +11,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
-
-import static org.assertj.core.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.BDDMockito.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 
 @ExtendWith(MockitoExtension.class)
 class QnaServiceTest {


### PR DESCRIPTION
## #️⃣연관된 이슈

> 

## 📝작업 내용

> 어드민 QNA 답변 기능 추가

## 💬리뷰 요구사항(선택)

1. 어드민 QNA 답변 기능을 추가하면서 SecurityConfig에 ADMIN 권한만 인가되도록 설정하였는데 테스트 코드에서는 다르게 작동함
  - AdminControllerTest에서 getAllUsers_ByUser() 와 replyQna() 가 기대값이 안나오는데 혹시 시큐리티 설정을 잘못 건든건지 확인 부탁 드려요
2. 기존의 이미지 엔티티 정보를 그대로 클라이언트에 응답하던 것을 이미지 데이터로 응답하도록 수정함
  - MultiPartFile 방식이 아닌 JSON 방식 그대로 응답을 보내기위해 이미지 데이터를 Base64로 인코딩하도록 구현했는데 이런 방식을 사용해도 되는지 검토 부탁드려요
