### PR TITLE
✨ 마이페이지 구현 및 어드민 페이지 구현

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -25,6 +25,7 @@
         "react-bootstrap": "^2.10.4",
         "react-daum-postcode": "^3.1.3",
         "react-dom": "^18.3.1",
+        "react-icons": "^5.3.0",
         "react-router-dom": "^6.26.0",
         "react-scripts": "5.0.1",
         "styled-components": "^6.1.12",
@@ -16951,6 +16952,14 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==",
       "license": "MIT"
+    },
+    "node_modules/react-icons": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.3.0.tgz",
+      "integrity": "sha512-DnUk8aFbTyQPSkCfF8dbX6kQjXA9DktMeJqfjrg6cK9vwQVMxmcA3BfP4QoiztVmEHtwlTgLFsPuH2NskKT6eg==",
+      "peerDependencies": {
+        "react": "*"
+      }
     },
     "node_modules/react-is": {
       "version": "17.0.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,6 +20,7 @@
     "react-bootstrap": "^2.10.4",
     "react-daum-postcode": "^3.1.3",
     "react-dom": "^18.3.1",
+    "react-icons": "^5.3.0",
     "react-router-dom": "^6.26.0",
     "react-scripts": "5.0.1",
     "styled-components": "^6.1.12",

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -15,6 +15,7 @@ import AdminQnaDetail from "./pages/admin/AdminQnaDetail";
 import MyPage from "./pages/user/MyPage";
 import AdminUsers from "./pages/admin/AdminUsers";
 import AdminQna from "./pages/admin/AdminQna";
+import Answer from "./components/admin/Answer";
 
 function App() {
     const location = useLocation();
@@ -37,6 +38,7 @@ function App() {
                 <Route path="/qnas/edit/:id" element={<EditQna/>}/>
 
                 {/* 관리자 경로 */}
+                <Route path="/admin" element={<AdminQna/>}/>
                 <Route path="/admin/users" element={<AdminUsers/>}/>
                 <Route path="/admin/qnas" element={<AdminQna/>}/>
                 <Route path="/admin/qnas/:id" element={<AdminQnaDetail />}/>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,7 +1,7 @@
 import './App.css';
 import Header from "./components/user/Header";
 import AdminHeader from "./components/admin/AdminHeader";
-import {Routes, Route, useLocation} from "react-router-dom";
+import {Route, Routes, useLocation} from "react-router-dom";
 import Recommend from "./pages/user/Recommend";
 import Qna from "./pages/user/Qna";
 import Login from "./pages/user/Login";
@@ -15,7 +15,6 @@ import AdminQnaDetail from "./pages/admin/AdminQnaDetail";
 import MyPage from "./pages/user/MyPage";
 import AdminUsers from "./pages/admin/AdminUsers";
 import AdminQna from "./pages/admin/AdminQna";
-import Answer from "./components/admin/Answer";
 
 function App() {
     const location = useLocation();

--- a/frontend/src/components/admin/AdminHeader.jsx
+++ b/frontend/src/components/admin/AdminHeader.jsx
@@ -2,24 +2,51 @@ import * as React from 'react';
 import Toolbar from '@mui/material/Toolbar';
 import Button from '@mui/material/Button';
 import Typography from '@mui/material/Typography';
-import {useNavigate} from "react-router-dom";
+import { useNavigate } from "react-router-dom";
+import api from '../Api'; // Axios 인스턴스 불러오기
 
 function AdminHeader() {
-    const nav = useNavigate();
+    const navigate = useNavigate();
+
+    const handleLogout = async () => {
+        try {
+            // 서버에 로그아웃 요청 보내기
+            await api.post('/api/v1/logout');
+
+            // 쿠키 제거
+            document.cookie = 'accessToken=; Max-Age=0; path=/;';
+            document.cookie = 'nickname=; Max-Age=0; path=/;';
+            document.cookie = 'role=; Max-Age=0; path=/;'; // role 쿠키 제거
+
+            // 로그아웃 후 홈으로 이동
+            alert("로그아웃 되었습니다.");
+            navigate('/');
+        } catch (error) {
+            console.error("로그아웃 중 오류가 발생했습니다:", error);
+            alert("로그아웃 중 오류가 발생했습니다.");
+        }
+    };
 
     const navigateTo = (path) => {
-        nav(path);
+        navigate(path);
     }
 
     return (
-        <Toolbar sx={{ borderBottom: 1, borderColor: 'divider' }}>
-            <Button size="small" onClick={() => navigateTo('/admin')}>admin Home</Button>
-            <Button size="small" onClick={() => navigateTo('/admin/users')}>admin users</Button>
-            <Button size="small" onClick={() => navigateTo('/admin/qnas')}>Q&A</Button>
+        <Toolbar sx={{ borderBottom: 1, borderColor: 'divider', backgroundColor: '#333', color: '#fff' }}>
+            <Button size="small" onClick={() => navigateTo('/')} sx={{ color: '#fff' }}>
+                HOME
+            </Button>
+            <Button size="small" onClick={() => navigateTo('/admin/qnas')} sx={{ color: '#fff' }}>
+                Q&A
+            </Button>
+            <Button size="small" onClick={() => navigateTo('/admin/users')} sx={{ color: '#fff' }}>
+                USERS
+            </Button>
 
-            <Typography align="center" sx={{ flex: 1 }}/>
-            <Button sx={{ml: 1}} variant="outlined" size="small" onClick={() => navigateTo('/login')}>login</Button>
-            <Button sx={{ml: 1}} variant="contained" size="small">logout</Button>
+            <Typography align="center" sx={{ flex: 1 }} />
+            <Button sx={{ ml: 1, backgroundColor: '#ff6347', color: '#fff' }} variant="contained" size="small" onClick={handleLogout}>
+                로그아웃
+            </Button>
         </Toolbar>
     );
 }

--- a/frontend/src/components/admin/AdminQnaList.jsx
+++ b/frontend/src/components/admin/AdminQnaList.jsx
@@ -5,13 +5,24 @@ import TableBody from '@mui/material/TableBody';
 import TableCell from '@mui/material/TableCell';
 import TableContainer from '@mui/material/TableContainer';
 import TableHead from '@mui/material/TableHead';
-import TablePagination from '@mui/material/TablePagination';
 import TableRow from '@mui/material/TableRow';
 import LockIcon from '@mui/icons-material/Lock';
-import { useNavigate } from 'react-router-dom'; // React Router의 useNavigate 훅을 가져옴
+import CircularProgress from '@mui/material/CircularProgress';
+import { useNavigate } from 'react-router-dom';
+import TextField from '@mui/material/TextField';
+import Button from '@mui/material/Button';
+import MenuItem from '@mui/material/MenuItem';
+import Select from '@mui/material/Select';
+import FormControl from '@mui/material/FormControl';
+import InputLabel from '@mui/material/InputLabel';
+import Box from '@mui/material/Box';
+import Pagination from '@mui/material/Pagination';
+import Checkbox from '@mui/material/Checkbox';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import api from '../Api';
 
 const columns = [
-    { id: 'id', label: 'id', minWidth: 10, align: 'center' },
+    { id: 'id', label: '글 번호', minWidth: 10, align: 'center' },
     { id: 'category', label: '유형', minWidth: 30, align: 'center' },
     { id: 'title', label: '제목', minWidth: 100, align: 'center' },
     { id: 'user', label: '작성자', minWidth: 100, align: 'center' },
@@ -19,62 +30,193 @@ const columns = [
     { id: 'createdDate', label: '작성일자', minWidth: 30, align: 'center' },
 ];
 
-function createData(id, category, title, user, isBlind, isAnswer, createdDate) {
-    return { id, category, title, user, isBlind, isAnswer, createdDate };
+// 카테고리 맵핑
+const categoryMap = {
+    "전체": "",
+    "일반 질문": "GENERAL",
+    "계정 관련": "ACCOUNT",
+    "기술 지원": "TECH_SUPPORT",
+    "기타": "OTHER",
+};
+
+// 날짜 배열을 원하는 형식으로 변환하는 함수
+function formatDateTime(dateArray) {
+    if (!dateArray || dateArray.length < 6) {
+        return "Invalid Date";
+    }
+
+    const year = String(dateArray[0]).slice(2); // '2024' -> '24'
+    const month = String(dateArray[1]).padStart(2, '0'); // '8' -> '08'
+    const day = String(dateArray[2]).padStart(2, '0'); // '20'
+    const hour = String(dateArray[3]).padStart(2, '0'); // '16'
+    const minute = String(dateArray[4]).padStart(2, '0'); // '16'
+
+    // 원하는 형식으로 변환
+    return `${year}.${month}.${day} ${hour}:${minute}`;
 }
 
-const rows = [
-    createData(1, '일반 질문', '일반 비공개 질문제목이에용', '박상은', true, false, '2024-08-02'),
-    createData(2, '일반 질문', '일반 공개 질문제목이에용', '박상은', false, false, '2024-08-02'),
-    createData(3, '일반 질문', '일반 공개 & 답변 완료 질문제목이에용', '박상은', false, true, '2024-08-02'),
-];
-
 export default function AdminQnaList() {
-    const [page, setPage] = React.useState(0);
-    const [rowsPerPage, setRowsPerPage] = React.useState(10);
-    const navigate = useNavigate(); // useNavigate 훅을 사용
+    const [page, setPage] = React.useState(1);
+    const [rowsPerPage, setRowsPerPage] = React.useState(10); // 클라이언트 측에서만 관리
+    const [rows, setRows] = React.useState([]);
+    const [loading, setLoading] = React.useState(true);
+    const [totalRows, setTotalRows] = React.useState(0);
+    const [title, setTitle] = React.useState('');
+    const [category, setCategory] = React.useState('');
+    const [notAnswered, setNotAnswered] = React.useState(false);  // "미답변 질문만 보기" 상태 추가
+    const navigate = useNavigate();
 
-    const handleChangePage = (event, newPage) => {
-        setPage(newPage);
+    React.useEffect(() => {
+        fetchData();  // 페이지, "미답변 질문만 보기" 값이 변경될 때마다 데이터 로드
+    }, [page, notAnswered]);
+
+    const fetchData = async () => {
+        setLoading(true);
+
+        try {
+            const response = await api.get('/api/v1/admins/qnas', {
+                params: {
+                    page: page - 1,  // 서버에서 0 기반 페이지 처리
+                    title: title,
+                    category: categoryMap[category],   // 카테고리 맵핑된 값 사용
+                    notAnswered: notAnswered,  // "미답변 질문만 보기" 값 추가
+                },
+            });
+
+            const data = response.data;
+            setRows(data.content.map((item) => ({
+                id: item.id,
+                category: item.category,
+                title: item.title,
+                user: item.user.nickname,
+                isBlind: item.isBlind,
+                isAnswer: item.isAnswer,
+                createdDate: formatDateTime(item.createdDate),  // 날짜 형식 변환
+            })));
+            setTotalRows(data.totalElements);
+        } catch (error) {
+            if (error.response && (error.response.status === 400 ||
+                error.response.status === 401 ||
+                error.response.status === 403)) {
+                alert('로그인한 유저만 사용 가능합니다.');
+                navigate('/login');
+            } else {
+                console.error('Failed to fetch data', error);
+            }
+        } finally {
+            setLoading(false);
+        }
     };
 
-    const handleChangeRowsPerPage = (event) => {
-        setRowsPerPage(+event.target.value);
-        setPage(0);
+    const handleSearch = () => {
+        setPage(1);  // 페이지를 초기화하고
+        fetchData();  // 검색을 수행
+    };
+
+    const handleChangePage = (event, value) => {
+        setPage(value);
     };
 
     const handleRowClick = (id) => {
-        navigate(`/admin/qnas/${id}`); // 해당 id로 페이지 이동
+        navigate(`/admins/qnas/${id}`);
+    };
+
+    const handleCategoryChange = (event) => {
+        setCategory(event.target.value);
+    };
+
+    const handleTitleChange = (event) => {
+        setTitle(event.target.value);
+    };
+
+    const handleNotAnsweredChange = (event) => {
+        setNotAnswered(event.target.checked);
+    };
+
+    // 엔터키 입력 시 검색 함수
+    const handleKeyDown = (event) => {
+        if (event.key === 'Enter') {
+            handleSearch();  // 엔터키 입력 시 검색 수행
+        }
     };
 
     return (
         <Paper sx={{ width: '100%', overflow: 'hidden' }}>
-            <TableContainer sx={{ maxHeight: 440 }}>
-                <Table stickyHeader aria-label="sticky table">
-                    <TableHead>
-                        <TableRow>
-                            {columns.map((column) => (
-                                <TableCell
-                                    key={column.id}
-                                    align={column.align}
-                                    style={{ minWidth: column.minWidth }}
-                                >
-                                    {column.label}
-                                </TableCell>
-                            ))}
-                        </TableRow>
-                    </TableHead>
-                    <TableBody>
-                        {rows
-                            .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
-                            .map((row) => (
+            {/* 검색 바 */}
+            <Box sx={{ padding: '16px', display: 'flex', alignItems: 'center', gap: '8px' }}>
+                <FormControl variant="outlined" size="small" style={{ minWidth: 150 }}>
+                    <InputLabel>카테고리</InputLabel>
+                    <Select
+                        value={category}
+                        onChange={handleCategoryChange}
+                        label="카테고리"
+                    >
+                        <MenuItem value="">
+                            <em>전체</em>
+                        </MenuItem>
+                        <MenuItem value="일반 질문">일반 질문</MenuItem>
+                        <MenuItem value="계정 관련">계정 관련</MenuItem>
+                        <MenuItem value="기술 지원">기술 지원</MenuItem>
+                        <MenuItem value="기타">기타</MenuItem>
+                    </Select>
+                </FormControl>
+                <TextField
+                    label="제목"
+                    variant="outlined"
+                    value={title}
+                    onChange={handleTitleChange}
+                    onKeyDown={handleKeyDown}  // 엔터키 입력 시 검색
+                    size="small"
+                />
+                <Button variant="contained" color="primary" onClick={handleSearch}>
+                    검색
+                </Button>
+                <FormControlLabel
+                    control={
+                        <Checkbox
+                            checked={notAnswered}
+                            onChange={handleNotAnsweredChange}
+                            color="primary"
+                        />
+                    }
+                    label={
+                        <span style={{ color: notAnswered ? 'red' : 'inherit' }}>
+                            답변 대기만 보기
+                        </span>
+                    }
+                    sx={{ marginLeft: 'auto' }}  // 체크박스를 오른쪽으로 이동
+                />
+            </Box>
+            {/* 테이블 */}
+            <TableContainer>
+                {loading ? (
+                    <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%' }}>
+                        <CircularProgress />
+                    </div>
+                ) : (
+                    <Table stickyHeader aria-label="sticky table">
+                        <TableHead>
+                            <TableRow>
+                                {columns.map((column) => (
+                                    <TableCell
+                                        key={column.id}
+                                        align={column.align}
+                                        style={{ minWidth: column.minWidth }}
+                                    >
+                                        {column.label}
+                                    </TableCell>
+                                ))}
+                            </TableRow>
+                        </TableHead>
+                        <TableBody>
+                            {rows.map((row) => (
                                 <TableRow
                                     hover
                                     role="checkbox"
                                     tabIndex={-1}
                                     key={row.id}
-                                    onClick={() => handleRowClick(row.id)} // Row 클릭 시 handleRowClick 호출
-                                    style={{ cursor: 'pointer' }} // 클릭 가능하도록 커서 변경
+                                    onClick={() => handleRowClick(row.id)}
+                                    style={{ cursor: 'pointer' }}
                                 >
                                     {columns.map((column) => {
                                         const value = row[column.id];
@@ -104,18 +246,21 @@ export default function AdminQnaList() {
                                     })}
                                 </TableRow>
                             ))}
-                    </TableBody>
-                </Table>
+                        </TableBody>
+                    </Table>
+                )}
             </TableContainer>
-            <TablePagination
-                rowsPerPageOptions={[10, 25, 100]}
-                component="div"
-                count={rows.length}
-                rowsPerPage={rowsPerPage}
-                page={page}
-                onPageChange={handleChangePage}
-                onRowsPerPageChange={handleChangeRowsPerPage}
-            />
+            {/* 페이징 */}
+            <Box sx={{ display: 'flex', justifyContent: 'center', padding: '16px' }}>
+                <Pagination
+                    count={Math.ceil(totalRows / rowsPerPage)}
+                    page={page}
+                    onChange={handleChangePage}
+                    color="primary"
+                    showFirstButton
+                    showLastButton
+                />
+            </Box>
         </Paper>
     );
 }

--- a/frontend/src/components/admin/AdminQnaList.jsx
+++ b/frontend/src/components/admin/AdminQnaList.jsx
@@ -98,8 +98,8 @@ export default function AdminQnaList() {
             if (error.response && (error.response.status === 400 ||
                 error.response.status === 401 ||
                 error.response.status === 403)) {
-                alert('로그인한 유저만 사용 가능합니다.');
-                navigate('/login');
+                alert('관리자만 접근 가능합니다.');
+                navigate('/');
             } else {
                 console.error('Failed to fetch data', error);
             }
@@ -118,7 +118,7 @@ export default function AdminQnaList() {
     };
 
     const handleRowClick = (id) => {
-        navigate(`/admins/qnas/${id}`);
+        navigate(`/admin/qnas/${id}`);
     };
 
     const handleCategoryChange = (event) => {

--- a/frontend/src/components/user/Header.jsx
+++ b/frontend/src/components/user/Header.jsx
@@ -36,21 +36,6 @@ function Header() {
         if (role) {
             setRole(role);
         }
-
-        // URL에서 토큰과 닉네임, role을 받아와 쿠키에 저장하는 로직
-        const urlParams = new URLSearchParams(window.location.search);
-        const accessTokenFromUrl = urlParams.get('accessToken');
-        const nicknameFromUrl = urlParams.get('nickname');
-        const roleFromUrl = urlParams.get('role');
-
-        if (accessTokenFromUrl && nicknameFromUrl && roleFromUrl) {
-            setCookie('accessToken', accessTokenFromUrl, 7);  // 7일 동안 유효
-            setCookie('nickname', nicknameFromUrl, 7);
-            setCookie('role', roleFromUrl, 7);
-            setIsLoggedIn(true);
-            setNickname(nicknameFromUrl);
-            setRole(roleFromUrl);
-        }
     }, []);
 
     const handleLogout = async () => {

--- a/frontend/src/components/user/Header.jsx
+++ b/frontend/src/components/user/Header.jsx
@@ -5,6 +5,7 @@ import Typography from '@mui/material/Typography';
 import { useNavigate } from "react-router-dom";
 import { useEffect, useState } from 'react';
 import api from '../Api'; // Axios 인스턴스 불러오기
+import StarIcon from '@mui/icons-material/Star'; // 별 모양 아이콘
 
 function getCookie(name) {
     const matches = document.cookie.match(new RegExp(
@@ -22,25 +23,33 @@ function Header() {
     const navigate = useNavigate();
     const [isLoggedIn, setIsLoggedIn] = useState(false);
     const [nickname, setNickname] = useState('');
+    const [role, setRole] = useState(''); // role 상태 추가
 
     useEffect(() => {
         const accessToken = getCookie("accessToken");
-        const nickname = getCookie("nickname"); // 쿠키에서 nickname 가져오기
+        const nickname = getCookie("nickname");
+        const role = getCookie("role"); // 쿠키에서 role 값 가져오기
         setIsLoggedIn(!!accessToken);
         if (nickname) {
             setNickname(nickname);
         }
+        if (role) {
+            setRole(role);
+        }
 
-        // URL에서 토큰과 닉네임을 받아와 쿠키에 저장하는 로직
+        // URL에서 토큰과 닉네임, role을 받아와 쿠키에 저장하는 로직
         const urlParams = new URLSearchParams(window.location.search);
         const accessTokenFromUrl = urlParams.get('accessToken');
         const nicknameFromUrl = urlParams.get('nickname');
+        const roleFromUrl = urlParams.get('role');
 
-        if (accessTokenFromUrl && nicknameFromUrl) {
+        if (accessTokenFromUrl && nicknameFromUrl && roleFromUrl) {
             setCookie('accessToken', accessTokenFromUrl, 7);  // 7일 동안 유효
             setCookie('nickname', nicknameFromUrl, 7);
+            setCookie('role', roleFromUrl, 7);
             setIsLoggedIn(true);
             setNickname(nicknameFromUrl);
+            setRole(roleFromUrl);
         }
     }, []);
 
@@ -52,10 +61,12 @@ function Header() {
             // 쿠키 제거
             document.cookie = 'accessToken=; Max-Age=0; path=/;';
             document.cookie = 'nickname=; Max-Age=0; path=/;';
+            document.cookie = 'role=; Max-Age=0; path=/;'; // role 쿠키 제거
 
             // 로그아웃이 성공하면 UI 상태 업데이트
             setIsLoggedIn(false);
             setNickname('');
+            setRole('');
             alert("로그아웃 되었습니다.");
             navigate('/'); // 로그아웃 후 홈으로 이동
         } catch (error) {
@@ -72,11 +83,15 @@ function Header() {
         <Toolbar sx={{ borderBottom: 1, borderColor: 'divider' }}>
             <Button size="small" onClick={() => navigateTo('/')}>Home</Button>
             <Button size="small" onClick={() => navigateTo('/qnas')}>Q&A</Button>
+            {role === 'ADMIN' && (
+                <Button size="small" onClick={() => navigateTo('/admin')}>ADMIN</Button>
+            )}
             <Typography align="center" sx={{ flex: 1 }} />
             {isLoggedIn ? (
                 <>
                     {nickname && (
-                        <Typography variant="body1" sx={{ marginRight: '10px' }}>
+                        <Typography variant="body1" sx={{ marginRight: '10px', display: 'flex', alignItems: 'center' }}>
+                            {role === 'ADMIN' && <StarIcon sx={{ color: 'gold', marginRight: '5px' }} />} {/* ADMIN일 경우 별 아이콘 추가 */}
                             {nickname}
                         </Typography>
                     )}

--- a/frontend/src/pages/admin/AdminQnaDetail.jsx
+++ b/frontend/src/pages/admin/AdminQnaDetail.jsx
@@ -82,7 +82,6 @@ export default function QnaDetail() {
         }
     };
 
-
     const handleEdit = () => {
         setIsEditing(true); // 입력 칸 활성화
         setAnswerContent(qnaData.answer.content); // 기존 답변을 입력칸에 미리 채움
@@ -233,7 +232,19 @@ export default function QnaDetail() {
                         variant="contained"
                         size="large"
                         fullWidth
-                        onClick={isEditing ? handleAnswerSubmit : handleEdit}
+                        onClick={() => {
+                            if (!qnaData.isAnswer && !isEditing) {
+                                if (answerContent.trim() === '') {
+                                    alert('답변 내용을 입력해주세요.');
+                                    return;
+                                }
+                                handleAnswerSubmit();
+                            } else if (isEditing) {
+                                handleAnswerSubmit();
+                            } else {
+                                handleEdit();
+                            }
+                        }}
                     >
                         {isEditing ? '답변 등록' : qnaData.isAnswer ? '답변 수정' : '답변 등록'}
                     </Button>

--- a/frontend/src/pages/admin/AdminQnaDetail.jsx
+++ b/frontend/src/pages/admin/AdminQnaDetail.jsx
@@ -1,100 +1,255 @@
 import * as React from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router-dom';
 import Container from "@mui/material/Container";
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import Grid from "@mui/material/Unstable_Grid2";
-import CustomButton from "../../components/CustomButton";
+import Button from '@mui/material/Button';
 import TextField from '@mui/material/TextField';
-
-const data = {
-    id: 1,
-    category: '일반 질문',
-    title: '일반 비공개 질문제목이에용',
-    user: '박상은',
-    isBlind: true,
-    isAnswer: false,
-    createdDate: '2024-08-02',
-    content: '이것은 질문의 상세 내용입니다. 여기에 질문의 구체적인 내용이 들어갑니다.',
-    answer: '이것은 답변의 내용입니다. 답변 내용이 여기에 들어갑니다.'
-};
+import CircularProgress from '@mui/material/CircularProgress';
+import Alert from '@mui/material/Alert';
+import api from '../../components/Api';
 
 export default function QnaDetail() {
     const { id } = useParams();
-    const [isAnswering, setIsAnswering] = React.useState(false); // 상태 관리
+    const navigate = useNavigate();
+    const [loading, setLoading] = React.useState(true);
+    const [qnaData, setQnaData] = React.useState(null);
+    const [error, setError] = React.useState(null);
+    const [imageUrls, setImageUrls] = React.useState([]);
+    const [answerContent, setAnswerContent] = React.useState('');
+    const [isEditing, setIsEditing] = React.useState(false);
 
-    const handleAnswerClick = () => {
-        setIsAnswering(true); // 버튼 클릭 시 상태 변경
+    React.useEffect(() => {
+        const fetchData = async () => {
+            setLoading(true);
+
+            try {
+                const response = await api.get(`/api/v1/admins/qnas/${id}`);
+                const data = response.data;
+                setQnaData(data);
+
+                const imagePromises = data.images.map(async (image) => {
+                    const imageResponse = await api.get(`/api/v1/qnas/image/${image.uuidName}`, {
+                        responseType: 'blob',
+                    });
+                    return {
+                        url: URL.createObjectURL(imageResponse.data),
+                        originName: image.originName
+                    };
+                });
+
+                const urls = await Promise.all(imagePromises);
+                setImageUrls(urls);
+            } catch (error) {
+                if (error.response && error.response.status === 400) {
+                    alert('에러 발생!');
+                    navigate('/admin/qnas');
+                } else {
+                    setError('Q&A 데이터를 불러오는데 실패했습니다.');
+                    console.error('Failed to fetch Q&A data:', error);
+                }
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        fetchData();
+    }, [id, navigate]);
+
+    const handleAnswerChange = (event) => {
+        setAnswerContent(event.target.value);
     };
+
+    const handleAnswerSubmit = async () => {
+        if (answerContent.trim() === '') {
+            alert('답변 내용을 입력해주세요.');
+            return;
+        }
+
+        try {
+            // 답변 내용만 서버에 전송
+            await api.post(`/api/v1/admins/qnas/${id}`, answerContent, {
+                headers: {
+                    'Content-Type': 'text/plain',
+                }
+            });
+            alert('답변이 등록되었습니다.');
+            window.location.reload(); // 페이지 새로고침
+        } catch (error) {
+            console.error('답변 등록 실패:', error);
+            alert('답변 등록에 실패했습니다.');
+        }
+    };
+
+
+    const handleEdit = () => {
+        setIsEditing(true); // 입력 칸 활성화
+        setAnswerContent(qnaData.answer.content); // 기존 답변을 입력칸에 미리 채움
+    };
+
+    const handleDelete = async () => {
+        if (window.confirm("정말 삭제하시겠습니까?")) {
+            try {
+                await api.delete(`/api/v1/qnas/${id}`);
+                alert("삭제되었습니다.");
+                navigate('/admin/qnas');
+            } catch (error) {
+                console.error("삭제 실패:", error);
+                alert("삭제에 실패했습니다.");
+            }
+        }
+    };
+
+    function formatDateTime(dateArray) {
+        if (!dateArray || dateArray.length < 6) {
+            return "Invalid Date";
+        }
+
+        const year = String(dateArray[0]).slice(0); // '2024'
+        const month = String(dateArray[1]).padStart(2, '0'); // '8' -> '08'
+        const day = String(dateArray[2]).padStart(2, '0'); // '20'
+        const hour = String(dateArray[3]).padStart(2, '0'); // '16'
+        const minute = String(dateArray[4]).padStart(2, '0'); // '16'
+        return `${year}년 ${month}월 ${day}일 ${hour}시 ${minute}분`;
+    }
+
+    const handleImageError = (index) => {
+        setImageUrls((prevUrls) =>
+            prevUrls.map((img, i) =>
+                i === index ? { ...img, url: null } : img
+            )
+        );
+    };
+
+    if (loading) {
+        return (
+            <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100vh' }}>
+                <CircularProgress />
+            </Box>
+        );
+    }
+
+    if (error) {
+        return (
+            <Container component="main" maxWidth="md" sx={{ marginTop: 4, marginBottom: 4 }}>
+                <Alert severity="error">{error}</Alert>
+            </Container>
+        );
+    }
 
     return (
         <Container component="main" maxWidth="md" sx={{ marginTop: 4, marginBottom: 4 }}>
             <Box sx={{ marginBottom: 2 }}>
-                <Typography variant="h5" align="center" gutterBottom>
-                    {data.title}
+                <Typography variant="h6" align="center" color="textSecondary" gutterBottom>
+                    {qnaData.category}
                 </Typography>
                 <Box display="flex" justifyContent="space-between" alignItems="center">
                     <Typography variant="body1">
-                        <strong>ID:</strong> {data.id}
+                        <strong>글 번호:</strong> {qnaData.id}
                     </Typography>
                     <Typography variant="body1">
-                        <strong>유형:</strong> {data.category}
-                    </Typography>
-                    <Typography variant="body1">
-                        <strong>작성자:</strong> {data.user}
+                        <strong>작성자:</strong> {qnaData.user.nickname}
                     </Typography>
                 </Box>
                 <Box display="flex" justifyContent="space-between" alignItems="center" mt={1}>
                     <Typography variant="body1">
-                        <strong>답변 상태:</strong> <span style={{ color: data.isAnswer ? 'green' : 'red' }}>
-                            {data.isAnswer ? '답변 완료' : '답변 대기'}
+                        <strong>답변 상태:</strong> <span style={{ color: qnaData.isAnswer ? 'green' : '#FF6347' }}>
+                            {qnaData.isAnswer ? '답변 완료' : '답변 대기'}
                         </span>
                     </Typography>
                     <Typography variant="body1">
-                        <strong>작성일자:</strong> {data.createdDate}
+                        <strong>작성일자:</strong> {formatDateTime(qnaData.createdDate)}
                     </Typography>
                 </Box>
             </Box>
 
-            <Box sx={{ marginTop: 4 }}>
-                <Typography variant="h6" gutterBottom>
-                    내용
-                </Typography>
-                <Typography variant="body1" paragraph>
-                    {data.content}
-                </Typography>
-
-                <Typography variant="h6" gutterBottom>
-                    답변
-                </Typography>
-                <Typography variant="body1">
-                    {data.answer}
+            <Box sx={{ marginTop: 6, marginBottom: 2, borderBottom: '1px solid #ddd', paddingBottom: 2 }}>
+                <Typography variant="h4" align="left" gutterBottom>
+                    {qnaData.title}
                 </Typography>
             </Box>
-            {!isAnswering && (
-                <Grid container spacing={2} sx={{ marginTop: '30px' }}>
-                    <Grid xs={4}></Grid>
-                    <Grid xs={4}>
-                        <CustomButton text={"답변 달기"} variant={"contained"} onClick={handleAnswerClick} />
-                    </Grid>
-                </Grid>
-            )}
-            {isAnswering && (
-                <Grid container spacing={2} sx={{ marginTop: '30px' }}>
-                    <Grid xs={10}>
+
+            <Box sx={{ marginTop: 4 }}>
+                {/* 이미지 표시 */}
+                <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', marginBottom: 4 }}>
+                    {imageUrls.map((img, index) => (
+                        img.url ? (
+                            <img
+                                key={index}
+                                src={img.url}
+                                alt={img.originName}
+                                style={{ maxWidth: '100%', marginBottom: '16px' }}
+                                onError={() => handleImageError(index)}
+                            />
+                        ) : (
+                            <Typography key={index} variant="body1" color="textSecondary">
+                                {img.originName}
+                            </Typography>
+                        )
+                    ))}
+                </Box>
+
+                <Typography variant="h6" gutterBottom sx={{ textIndent: '20px' }}>
+                    본문
+                </Typography>
+                <Typography variant="body1" paragraph sx={{ whiteSpace: 'pre-wrap', backgroundColor: '#f9f9f9', padding: 2, borderRadius: 1 }}>
+                    {qnaData.content}
+                </Typography>
+
+                {qnaData.isAnswer && !isEditing && (
+                    <>
+                        <Typography variant="h6" gutterBottom sx={{ textIndent: '20px' }}>
+                            답변
+                        </Typography>
+                        <Typography variant="body1" sx={{ whiteSpace: 'pre-wrap', backgroundColor: '#f0f8ff', padding: '15px 20px', borderRadius: '10px', border: '1px solid #b3d4fc' }}>
+                            {qnaData.answer.content}
+                        </Typography>
+                        <Typography variant="body2" sx={{ textAlign: 'right', color: 'textSecondary', marginTop: 2 }}>
+                            작성일: {formatDateTime(qnaData.answer.createdDate)}
+                        </Typography>
+                    </>
+                )}
+
+                {/* 답변 입력 박스 */}
+                {(isEditing || !qnaData.isAnswer) && (
+                    <Box sx={{ marginTop: 4, padding: 2, borderRadius: 1 }}>
                         <TextField
-                            label="답변 입력"
+                            label="답변"
                             multiline
-                            rows={4}
                             fullWidth
+                            rows={4}
                             variant="outlined"
+                            value={answerContent}
+                            onChange={handleAnswerChange}
+                            sx={{ marginBottom: 2 }}
                         />
-                    </Grid>
-                    <Grid xs={2}>
-                        <CustomButton text={"답변 달기"} variant={"contained"} sx={{ height: '100%' }}/>
-                    </Grid>
+                    </Box>
+                )}
+            </Box>
+            <Grid container spacing={2} sx={{ marginTop: '30px', justifyContent: 'flex-end' }}>
+                <Grid xs={3}>
+                    <Button
+                        variant="contained"
+                        size="large"
+                        fullWidth
+                        onClick={isEditing ? handleAnswerSubmit : handleEdit}
+                    >
+                        {isEditing ? '답변 등록' : qnaData.isAnswer ? '답변 수정' : '답변 등록'}
+                    </Button>
                 </Grid>
-            )}
+                <Grid xs={3}>
+                    <Button
+                        variant="contained"
+                        color="error"
+                        size="large"
+                        fullWidth
+                        onClick={handleDelete}
+                    >
+                        삭제
+                    </Button>
+                </Grid>
+            </Grid>
         </Container>
     );
 }

--- a/frontend/src/pages/admin/AdminQnaDetail.jsx
+++ b/frontend/src/pages/admin/AdminQnaDetail.jsx
@@ -23,6 +23,7 @@ export default function QnaDetail() {
     React.useEffect(() => {
         const fetchData = async () => {
             setLoading(true);
+            setError(null);  // 이전 에러 메시지를 초기화
 
             try {
                 const response = await api.get(`/api/v1/admins/qnas/${id}`);
@@ -43,10 +44,10 @@ export default function QnaDetail() {
                 setImageUrls(urls);
             } catch (error) {
                 if (error.response && error.response.status === 400) {
-                    alert('에러 발생!');
+                    setError('비공개 게시물입니다.');
                     navigate('/admin/qnas');
                 } else {
-                    setError('Q&A 데이터를 불러오는데 실패했습니다.');
+                    setError('Q&A 데이터를 불러오는 중 오류가 발생했습니다.');
                     console.error('Failed to fetch Q&A data:', error);
                 }
             } finally {
@@ -62,13 +63,14 @@ export default function QnaDetail() {
     };
 
     const handleAnswerSubmit = async () => {
+        setError(null); // 이전 에러 메시지를 초기화
+
         if (answerContent.trim() === '') {
-            alert('답변 내용을 입력해주세요.');
+            setError('답변 내용을 입력해주세요.');
             return;
         }
 
         try {
-            // 답변 내용만 서버에 전송
             await api.post(`/api/v1/admins/qnas/${id}`, answerContent, {
                 headers: {
                     'Content-Type': 'text/plain',
@@ -78,7 +80,7 @@ export default function QnaDetail() {
             window.location.reload(); // 페이지 새로고침
         } catch (error) {
             console.error('답변 등록 실패:', error);
-            alert('답변 등록에 실패했습니다.');
+            setError('답변 등록에 실패했습니다.');
         }
     };
 
@@ -88,6 +90,8 @@ export default function QnaDetail() {
     };
 
     const handleDelete = async () => {
+        setError(null); // 이전 에러 메시지를 초기화
+
         if (window.confirm("정말 삭제하시겠습니까?")) {
             try {
                 await api.delete(`/api/v1/qnas/${id}`);
@@ -95,7 +99,7 @@ export default function QnaDetail() {
                 navigate('/admin/qnas');
             } catch (error) {
                 console.error("삭제 실패:", error);
-                alert("삭제에 실패했습니다.");
+                setError("삭제에 실패했습니다.");
             }
         }
     };
@@ -126,14 +130,6 @@ export default function QnaDetail() {
             <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100vh' }}>
                 <CircularProgress />
             </Box>
-        );
-    }
-
-    if (error) {
-        return (
-            <Container component="main" maxWidth="md" sx={{ marginTop: 4, marginBottom: 4 }}>
-                <Alert severity="error">{error}</Alert>
-            </Container>
         );
     }
 
@@ -225,7 +221,14 @@ export default function QnaDetail() {
                         />
                     </Box>
                 )}
+                {/* 에러 메시지 표시 위치 변경 */}
+                {error && (
+                    <Alert severity="error" sx={{ mt: 2 }}>
+                        {error}
+                    </Alert>
+                )}
             </Box>
+
             <Grid container spacing={2} sx={{ marginTop: '30px', justifyContent: 'flex-end' }}>
                 <Grid xs={3}>
                     <Button
@@ -235,7 +238,7 @@ export default function QnaDetail() {
                         onClick={() => {
                             if (!qnaData.isAnswer && !isEditing) {
                                 if (answerContent.trim() === '') {
-                                    alert('답변 내용을 입력해주세요.');
+                                    setError('답변 내용을 입력해주세요.');
                                     return;
                                 }
                                 handleAnswerSubmit();

--- a/frontend/src/pages/admin/AdminUsers.jsx
+++ b/frontend/src/pages/admin/AdminUsers.jsx
@@ -1,7 +1,252 @@
-import * as React from "react";
+import React, { useState, useEffect } from 'react';
+import {
+    Container,
+    Box,
+    Typography,
+    TextField,
+    Button,
+    Table,
+    TableBody,
+    TableCell,
+    TableContainer,
+    TableHead,
+    TableRow,
+    Paper,
+    CircularProgress,
+    Alert,
+    InputAdornment,
+    Pagination,
+    IconButton,
+} from '@mui/material';
+import SearchIcon from '@mui/icons-material/Search';
+import StarIcon from '@mui/icons-material/Star';
+import ClearIcon from '@mui/icons-material/Clear';
+import SortIcon from '@mui/icons-material/Sort';
+import api from '../../components/Api';
 
 export default function AdminUsers() {
+    const [users, setUsers] = useState([]);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState(null);
+    const [searchName, setSearchName] = useState('');
+    const [page, setPage] = useState(1);
+    const [rowsPerPage, setRowsPerPage] = useState(10);
+    const [totalElements, setTotalElements] = useState(0);
+    const [sortField, setSortField] = useState('');
+    const [sortDirection, setSortDirection] = useState('');
+
+    useEffect(() => {
+        fetchUsers();
+    }, [page, rowsPerPage, sortField, sortDirection]);
+
+    const fetchUsers = async () => {
+        setLoading(true);
+        try {
+            const sortParam = sortField ? `${sortField},${sortDirection}` : '';
+            const response = await api.get('/api/v1/admins/users', {
+                params: {
+                    name: searchName,
+                    page: page - 1,
+                    size: rowsPerPage,
+                    sort: sortParam,
+                },
+            });
+            setUsers(response.data.content);
+            setTotalElements(response.data.totalElements);
+            setError(null);
+        } catch (error) {
+            console.error('Failed to fetch users:', error);
+            setError('유저 데이터를 불러오는데 실패했습니다.');
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const handleSearchChange = (event) => {
+        setSearchName(event.target.value);
+    };
+
+    const handleSearch = () => {
+        setPage(1);
+        fetchUsers();
+    };
+
+    const handlePageChange = (event, value) => {
+        setPage(value);
+    };
+
+    const handleKeyPress = (event) => {
+        if (event.key === 'Enter') {
+            handleSearch();
+        }
+    };
+
+    const handleSort = (field) => {
+        if (sortField === field) {
+            setSortDirection(sortDirection === 'asc' ? 'desc' : 'asc');
+        } else {
+            setSortField(field);
+            setSortDirection('asc');
+        }
+    };
+
+    const handleRemoveSort = () => {
+        setSortField('');
+        setSortDirection('');
+    };
+
+    const formatCreatedDate = (dateString) => {
+        const date = new Date(dateString);
+        const year = String(date.getFullYear()).slice(-2);
+        const month = String(date.getMonth() + 1).padStart(2, '0');
+        const day = String(date.getDate()).padStart(2, '0');
+        return `${year}.${month}.${day}`;
+    };
+
+    const formatProvider = (provider) => {
+        switch (provider) {
+            case 'KAKAO':
+                return '카카오';
+            case 'DEFAULT':
+            default:
+                return '일반';
+        }
+    };
+
+    const formatRole = (role) => {
+        return role === 'ADMIN' ? (
+            <>
+                <StarIcon sx={{ fontSize: 'small', color: 'gold', verticalAlign: 'middle' }} /> 관리자
+            </>
+        ) : (
+            '사용자'
+        );
+    };
+
+    const formatLoginStatus = (isLogin) => {
+        return isLogin ? (
+            <span style={{ color: 'green' }}>접속중</span>
+        ) : (
+            <span style={{ color: 'red' }}>미접속</span>
+        );
+    };
+
+    if (loading) {
+        return (
+            <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100vh' }}>
+                <CircularProgress />
+            </Box>
+        );
+    }
+
+    if (error) {
+        return (
+            <Container component="main" maxWidth="md" sx={{ marginTop: 4, marginBottom: 4 }}>
+                <Alert severity="error">{error}</Alert>
+            </Container>
+        );
+    }
+
     return (
-        <>adminusers</>
+        <Container component="main" maxWidth="lg" sx={{ marginTop: 4, marginBottom: 4 }}>
+            <Typography variant="h4" gutterBottom>
+                유저 관리
+            </Typography>
+
+            <Box sx={{ display: 'flex', justifyContent: 'flex-start', alignItems: 'center', marginBottom: 2 }}>
+                <TextField
+                    label="닉네임 검색"
+                    variant="outlined"
+                    value={searchName}
+                    onChange={handleSearchChange}
+                    onKeyPress={handleKeyPress}
+                    InputProps={{
+                        startAdornment: (
+                            <InputAdornment position="start">
+                                <SearchIcon />
+                            </InputAdornment>
+                        ),
+                    }}
+                    sx={{ width: '300px', marginRight: 2 }}
+                />
+                <Button
+                    variant="contained"
+                    color="primary"
+                    onClick={handleSearch}
+                    sx={{ height: '100%' }}
+                >
+                    검색
+                </Button>
+            </Box>
+
+            <TableContainer component={Paper} sx={{ borderRadius: 2, boxShadow: 3 }}>
+                <Table>
+                    <TableHead>
+                        <TableRow sx={{ backgroundColor: '#f5f5f5' }}>
+                            {['id', 'serialId', 'provider', 'role', 'createdDate', 'nickname', 'isLogin'].map((field) => (
+                                <TableCell
+                                    key={field}
+                                    align="center"
+                                    onClick={() => handleSort(field)}
+                                    style={{ cursor: 'pointer', position: 'relative' }}
+                                    sx={{
+                                        '&:hover': {
+                                            backgroundColor: '#e0e0e0',
+                                        },
+                                    }}
+                                >
+                                    {field === 'id' && 'ID'}
+                                    {field === 'serialId' && '로그인 ID'}
+                                    {field === 'provider' && '로그인 방법'}
+                                    {field === 'role' && '등급'}
+                                    {field === 'createdDate' && '생성 날짜'}
+                                    {field === 'nickname' && '닉네임'}
+                                    {field === 'isLogin' && '접속 여부'}
+                                    {sortField === field && (
+                                        <IconButton
+                                            size="small"
+                                            onClick={(e) => {
+                                                e.stopPropagation();
+                                                handleRemoveSort();
+                                            }}
+                                            sx={{ position: 'absolute', right: 0, top: '50%', transform: 'translateY(-50%)', color: '#FF5722' }}
+                                        >
+                                            <ClearIcon fontSize="small" />
+                                        </IconButton>
+                                    )}
+                                    <SortIcon fontSize="small" sx={{ verticalAlign: 'middle', marginLeft: 1 }} />
+                                </TableCell>
+                            ))}
+                        </TableRow>
+                    </TableHead>
+                    <TableBody>
+                        {users.map((user) => (
+                            <TableRow key={user.id} hover>
+                                <TableCell align="center">{user.id}</TableCell>
+                                <TableCell align="center">{user.serialId}</TableCell>
+                                <TableCell align="center">{formatProvider(user.provider)}</TableCell>
+                                <TableCell align="center">{formatRole(user.role)}</TableCell>
+                                <TableCell align="center">{formatCreatedDate(user.createdDate)}</TableCell>
+                                <TableCell align="center">{user.nickname}</TableCell>
+                                <TableCell align="center">{formatLoginStatus(user.isLogin)}</TableCell>
+                            </TableRow>
+                        ))}
+                    </TableBody>
+                </Table>
+            </TableContainer>
+
+            <Box sx={{ display: 'flex', justifyContent: 'center', padding: '16px' }}>
+                <Pagination
+                    count={Math.ceil(totalElements / rowsPerPage)}
+                    page={page}
+                    onChange={handlePageChange}
+                    color="primary"
+                    showFirstButton
+                    showLastButton
+                    siblingCount={1}
+                    boundaryCount={1}
+                />
+            </Box>
+        </Container>
     );
-};
+}

--- a/frontend/src/pages/user/Login.jsx
+++ b/frontend/src/pages/user/Login.jsx
@@ -4,22 +4,53 @@ import TextField from '@mui/material/TextField';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import Container from '@mui/material/Container';
+import Alert from '@mui/material/Alert';
 
 export default function SignIn() {
     const [loginId, setLoginId] = React.useState('');
     const [password, setPassword] = React.useState('');
+    const [error, setError] = React.useState(null);
+
+    const handleSubmit = async (event) => {
+        event.preventDefault();
+        setError(null);
+
+        if (!loginId || !password) {
+            setError('아이디와 패스워드를 모두 입력해 주세요.');
+            return;
+        }
+
+        try {
+            const response = await fetch(`${process.env.REACT_APP_API_BASE_URL}/api/v1/sign-in`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/x-www-form-urlencoded',
+                },
+                body: new URLSearchParams({
+                    serialId: loginId,
+                    password: password,
+                }),
+                credentials: 'include'
+            });
+
+            if (response.ok) {
+                // 로그인 성공 처리
+                window.location.href = '/';
+            } else {
+                // 로그인 실패 처리
+                const errorData = await response.json();
+                setError(errorData.message || '아이디와 패스워드를 확인해주세요.');
+            }
+        } catch (err) {
+            setError('서버와의 통신에 문제가 발생했습니다. 나중에 다시 시도해 주세요.');
+        }
+    };
 
     return (
         <Container component="main" maxWidth="xs">
             <Box sx={{ marginTop: 8, display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
                 <Typography component="h1" variant="h5">LOGIN</Typography>
-                <Box
-                    component="form"
-                    noValidate
-                    sx={{ mt: 1 }}
-                    method="POST"
-                    action={`${process.env.REACT_APP_API_BASE_URL}/api/v1/sign-in`}
-                >
+                <Box component="form" noValidate sx={{ mt: 1 }} onSubmit={handleSubmit}>
                     <TextField
                         margin="normal"
                         fullWidth
@@ -41,6 +72,11 @@ export default function SignIn() {
                         value={password}
                         onChange={(e) => setPassword(e.target.value)}
                     />
+                    {error && (
+                        <Alert severity="error" sx={{ mt: 2, mb: 2 }}>
+                            {error}
+                        </Alert>
+                    )}
                     <Button
                         type="submit"
                         fullWidth

--- a/frontend/src/pages/user/MyPage.jsx
+++ b/frontend/src/pages/user/MyPage.jsx
@@ -64,10 +64,11 @@ const MyPage = () => {
             {userInfo ? (
                 <>
                     <div style={styles.userInfo}>
-                        <p style={styles.userInfoText}>
-                            <strong style={styles.strong}>ID:</strong> {userInfo.serialId}
-                        </p>
-                        <p style={styles.userInfoText}>
+                        <div style={styles.userInfoItem}>
+                            <strong style={styles.strong}>ID:</strong>
+                            <span style={styles.userInfoText}>{userInfo.serialId}</span>
+                        </div>
+                        <div style={styles.userInfoItem}>
                             <strong style={styles.strong}>Nickname:</strong>
                             {isEditing ? (
                                 <input
@@ -77,18 +78,20 @@ const MyPage = () => {
                                     style={styles.input}
                                 />
                             ) : (
-                                <>
+                                <span style={styles.userInfoText}>
                                     {nickname}
                                     <FaEdit style={styles.editIcon} onClick={handleEditClick} />
-                                </>
+                                </span>
                             )}
-                        </p>
-                        <p style={styles.userInfoText}>
-                            <strong style={styles.strong}>등급:</strong> {roleDisplay}
-                        </p>
-                        <p style={styles.userInfoText}>
-                            <strong style={styles.strong}>로그인:</strong> {providerDisplay}
-                        </p>
+                        </div>
+                        <div style={styles.userInfoItem}>
+                            <strong style={styles.strong}>등급:</strong>
+                            <span style={styles.userInfoText}>{roleDisplay}</span>
+                        </div>
+                        <div style={styles.userInfoItem}>
+                            <strong style={styles.strong}>로그인:</strong>
+                            <span style={styles.userInfoText}>{providerDisplay}</span>
+                        </div>
                     </div>
                     {isEditing && (
                         <div style={styles.buttonContainer}>
@@ -123,20 +126,20 @@ const styles = {
         marginBottom: '20px',
     },
     userInfo: {
-        marginTop: '20px',
-        padding: '20px',
         backgroundColor: '#f9f9f9',
+        padding: '20px',
         borderRadius: '8px',
         boxShadow: 'inset 0 0 10px rgba(0, 0, 0, 0.05)',
-        position: 'relative',
     },
-    userInfoText: {
-        fontSize: '1.1em',
-        color: '#555',
-        lineHeight: '1.8',
-        margin: '10px 0',
+    userInfoItem: {
+        marginBottom: '15px',
         display: 'flex',
         alignItems: 'center',
+    },
+    userInfoText: {
+        marginLeft: '10px',
+        fontSize: '1.2em',
+        color: '#555',
     },
     strong: {
         color: '#4A90E2',
@@ -167,7 +170,6 @@ const styles = {
         border: 'none',
         borderRadius: '5px',
         cursor: 'pointer',
-        marginTop: '20px',
     },
     loading: {
         textAlign: 'center',

--- a/frontend/src/pages/user/MyPage.jsx
+++ b/frontend/src/pages/user/MyPage.jsx
@@ -1,11 +1,14 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import api from '../../components/Api'; // customAxios 파일 경로에 맞게 수정
+import api from '../../components/Api';
+import { FaEdit } from 'react-icons/fa';
 
 const MyPage = () => {
     const [userInfo, setUserInfo] = useState(null);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState(null);
+    const [isEditing, setIsEditing] = useState(false);
+    const [nickname, setNickname] = useState('');
     const navigate = useNavigate();
 
     useEffect(() => {
@@ -13,6 +16,7 @@ const MyPage = () => {
             try {
                 const response = await api.get('/api/v1/users');
                 setUserInfo(response.data.data);
+                setNickname(response.data.data.nickname);
                 setLoading(false);
             } catch (err) {
                 if (err.response && err.response.status === 400) {
@@ -27,6 +31,21 @@ const MyPage = () => {
 
         fetchUserInfo();
     }, [navigate]);
+
+    const handleEditClick = () => {
+        setIsEditing(true);
+    };
+
+    const handleSaveClick = async () => {
+        try {
+            // 서버로 닉네임 업데이트 요청
+            await api.post('/api/v1/auth/update', { nickname });
+            setIsEditing(false);
+            alert('내 정보가 변경되었습니다.');
+        } catch (err) {
+            alert('Failed to update nickname');
+        }
+    };
 
     if (loading) {
         return <div style={styles.loading}>Loading...</div>;
@@ -43,12 +62,42 @@ const MyPage = () => {
         <div style={styles.container}>
             <h1 style={styles.title}>My Page</h1>
             {userInfo ? (
-                <div style={styles.userInfo}>
-                    <p style={styles.userInfoText}><strong style={styles.strong}>ID:</strong> {userInfo.serialId}</p>
-                    <p style={styles.userInfoText}><strong style={styles.strong}>Nickname:</strong> {userInfo.nickname}</p>
-                    <p style={styles.userInfoText}><strong style={styles.strong}>등급:</strong> {roleDisplay}</p>
-                    <p style={styles.userInfoText}><strong style={styles.strong}>로그인:</strong> {providerDisplay}</p>
-                </div>
+                <>
+                    <div style={styles.userInfo}>
+                        <p style={styles.userInfoText}>
+                            <strong style={styles.strong}>ID:</strong> {userInfo.serialId}
+                        </p>
+                        <p style={styles.userInfoText}>
+                            <strong style={styles.strong}>Nickname:</strong>
+                            {isEditing ? (
+                                <input
+                                    type="text"
+                                    value={nickname}
+                                    onChange={(e) => setNickname(e.target.value)}
+                                    style={styles.input}
+                                />
+                            ) : (
+                                <>
+                                    {nickname}
+                                    <FaEdit style={styles.editIcon} onClick={handleEditClick} />
+                                </>
+                            )}
+                        </p>
+                        <p style={styles.userInfoText}>
+                            <strong style={styles.strong}>등급:</strong> {roleDisplay}
+                        </p>
+                        <p style={styles.userInfoText}>
+                            <strong style={styles.strong}>로그인:</strong> {providerDisplay}
+                        </p>
+                    </div>
+                    {isEditing && (
+                        <div style={styles.buttonContainer}>
+                            <button style={styles.saveButton} onClick={handleSaveClick}>
+                                저장하기
+                            </button>
+                        </div>
+                    )}
+                </>
             ) : (
                 <p>No user information available.</p>
             )}
@@ -79,15 +128,46 @@ const styles = {
         backgroundColor: '#f9f9f9',
         borderRadius: '8px',
         boxShadow: 'inset 0 0 10px rgba(0, 0, 0, 0.05)',
+        position: 'relative',
     },
     userInfoText: {
         fontSize: '1.1em',
         color: '#555',
         lineHeight: '1.8',
         margin: '10px 0',
+        display: 'flex',
+        alignItems: 'center',
     },
     strong: {
         color: '#4A90E2',
+    },
+    input: {
+        marginLeft: '10px',
+        padding: '5px',
+        fontSize: '1.1em',
+        borderRadius: '5px',
+        border: '1px solid #ccc',
+        width: '70%',
+    },
+    editIcon: {
+        marginLeft: '10px',
+        cursor: 'pointer',
+        color: '#4A90E2',
+    },
+    buttonContainer: {
+        display: 'flex',
+        justifyContent: 'center',
+        marginTop: '20px',
+    },
+    saveButton: {
+        padding: '10px 20px',
+        fontSize: '1.1em',
+        color: '#fff',
+        backgroundColor: '#4A90E2',
+        border: 'none',
+        borderRadius: '5px',
+        cursor: 'pointer',
+        marginTop: '20px',
     },
     loading: {
         textAlign: 'center',

--- a/frontend/src/pages/user/MyPage.jsx
+++ b/frontend/src/pages/user/MyPage.jsx
@@ -2,11 +2,12 @@ import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import api from '../../components/Api';
 import { FaEdit } from 'react-icons/fa';
+import Alert from "@mui/material/Alert";
 
 const MyPage = () => {
     const [userInfo, setUserInfo] = useState(null);
     const [loading, setLoading] = useState(true);
-    const [error, setError] = useState(null);
+    const [error, setError] = useState(null); // 서버 통신 및 기타 에러 상태
     const [isEditing, setIsEditing] = useState(false);
     const [nickname, setNickname] = useState('');
     const navigate = useNavigate();
@@ -37,13 +38,18 @@ const MyPage = () => {
     };
 
     const handleSaveClick = async () => {
+        if (nickname.trim() === '') {
+            setError('닉네임을 입력해 주세요.');
+            return;
+        }
+
         try {
-            // 서버로 닉네임 업데이트 요청
             await api.post('/api/v1/auth/update', { nickname });
             setIsEditing(false);
+            setError(null);
             alert('내 정보가 변경되었습니다.');
         } catch (err) {
-            alert('Failed to update nickname');
+            setError('Failed to update nickname.');
         }
     };
 
@@ -51,15 +57,11 @@ const MyPage = () => {
         return <div style={styles.loading}>Loading...</div>;
     }
 
-    if (error) {
-        return <div style={styles.error}>{error}</div>;
-    }
-
-    const roleDisplay = userInfo.eRole === 'ADMIN' ? '관리자' : '회원';
-    const providerDisplay = userInfo.eProvider === 'KAKAO' ? '카카오' : '일반';
-
     return (
         <div style={styles.container}>
+            {error && (
+                <Alert severity="error" style={styles.validationError}>{error}</Alert>
+            )}
             <h1 style={styles.title}>My Page</h1>
             {userInfo ? (
                 <>
@@ -71,12 +73,14 @@ const MyPage = () => {
                         <div style={styles.userInfoItem}>
                             <strong style={styles.strong}>Nickname:</strong>
                             {isEditing ? (
-                                <input
-                                    type="text"
-                                    value={nickname}
-                                    onChange={(e) => setNickname(e.target.value)}
-                                    style={styles.input}
-                                />
+                                <>
+                                    <input
+                                        type="text"
+                                        value={nickname}
+                                        onChange={(e) => setNickname(e.target.value)}
+                                        style={styles.input}
+                                    />
+                                </>
                             ) : (
                                 <span style={styles.userInfoText}>
                                     {nickname}
@@ -86,11 +90,11 @@ const MyPage = () => {
                         </div>
                         <div style={styles.userInfoItem}>
                             <strong style={styles.strong}>등급:</strong>
-                            <span style={styles.userInfoText}>{roleDisplay}</span>
+                            <span style={styles.userInfoText}>{userInfo.eRole === 'ADMIN' ? '관리자' : '회원'}</span>
                         </div>
                         <div style={styles.userInfoItem}>
                             <strong style={styles.strong}>로그인:</strong>
-                            <span style={styles.userInfoText}>{providerDisplay}</span>
+                            <span style={styles.userInfoText}>{userInfo.eProvider === 'KAKAO' ? '카카오' : '일반'}</span>
                         </div>
                     </div>
                     {isEditing && (
@@ -156,6 +160,9 @@ const styles = {
         marginLeft: '10px',
         cursor: 'pointer',
         color: '#4A90E2',
+    },
+    validationError: {
+        marginBottom: '20px',
     },
     buttonContainer: {
         display: 'flex',

--- a/frontend/src/pages/user/MyPage.jsx
+++ b/frontend/src/pages/user/MyPage.jsx
@@ -12,6 +12,12 @@ const MyPage = () => {
     const [nickname, setNickname] = useState('');
     const navigate = useNavigate();
 
+    function setCookie(name, value, days) {
+        const expires = new Date(Date.now() + days * 864e5).toUTCString();
+        document.cookie = name + '=' + encodeURIComponent(value) + '; expires=' + expires + '; path=/';
+    }
+
+
     useEffect(() => {
         const fetchUserInfo = async () => {
             try {
@@ -47,7 +53,9 @@ const MyPage = () => {
             await api.post('/api/v1/auth/update', { nickname });
             setIsEditing(false);
             setError(null);
+            setCookie('nickname', nickname);
             alert('내 정보가 변경되었습니다.');
+            window.location.reload();
         } catch (err) {
             setError('Failed to update nickname.');
         }

--- a/frontend/src/pages/user/NewQna.jsx
+++ b/frontend/src/pages/user/NewQna.jsx
@@ -17,7 +17,8 @@ import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
 import IconButton from '@mui/material/IconButton';
 import CloseIcon from '@mui/icons-material/Close';
-import api from '../../components/Api';  // api.js 파일을 가져옵니다.
+import Alert from '@mui/material/Alert';
+import api from '../../components/Api';
 
 export default function NewQna() {
     const [category, setCategory] = React.useState('');
@@ -25,6 +26,7 @@ export default function NewQna() {
     const [content, setContent] = React.useState('');
     const [files, setFiles] = React.useState([]);
     const [isBlind, setIsBlind] = React.useState(false);
+    const [error, setError] = React.useState(null); // 에러 상태 추가
     const navigate = useNavigate();
 
     const handleChange = (event) => {
@@ -52,14 +54,15 @@ export default function NewQna() {
     };
 
     const handleSubmit = async () => {
+        setError(null); // 에러 상태 초기화
+
         if (!title || !content || !category) {
-            alert('모든 필드를 채워주세요.');
+            setError('모든 값을 채워주세요.');
             return;
         }
 
         const formData = new FormData();
 
-        // JSON 데이터를 Blob으로 추가
         const json = JSON.stringify({
             title,
             content,
@@ -69,7 +72,6 @@ export default function NewQna() {
         const jsonBlob = new Blob([json], { type: 'application/json' });
         formData.append('qnaRequestDto', jsonBlob);
 
-        // 모든 파일을 FormData에 추가
         files.forEach(({ file }) => {
             formData.append('images', file);
         });
@@ -80,11 +82,10 @@ export default function NewQna() {
                     'Content-Type': 'multipart/form-data',
                 },
             });
-            alert('작성되었습니다.');
             navigate('/qnas');
         } catch (error) {
             console.error('작성 실패:', error);
-            alert('작성에 실패했습니다.');
+            setError('작성에 실패했습니다.');
         }
     };
 
@@ -103,6 +104,9 @@ export default function NewQna() {
     return (
         <Container component="main" maxWidth="sm" sx={{ marginTop: 4, marginBottom: 4 }}>
             <Stack spacing={3}>
+                {error && (
+                    <Alert severity="error">{error}</Alert>
+                )}
                 <FormControl fullWidth>
                     <FormControlLabel
                         control={
@@ -182,7 +186,7 @@ export default function NewQna() {
                         <VisuallyHiddenInput
                             type="file"
                             accept="image/*"
-                            multiple  // 여러 파일을 선택 가능하게 함
+                            multiple
                             onChange={fileChange}
                         />
                     </Button>

--- a/frontend/src/pages/user/QnaDetail.jsx
+++ b/frontend/src/pages/user/QnaDetail.jsx
@@ -125,7 +125,7 @@ export default function QnaDetail() {
                 </Box>
                 <Box display="flex" justifyContent="space-between" alignItems="center" mt={1}>
                     <Typography variant="body1">
-                        <strong>답변 상태:</strong> <span style={{ color: qnaData.isAnswer ? 'green' : 'red' }}>
+                        <strong>답변 상태:</strong> <span style={{ color: qnaData.isAnswer ? 'green' : '#FF6347' }}>
                             {qnaData.isAnswer ? '답변 완료' : '답변 대기'}
                         </span>
                     </Typography>
@@ -161,16 +161,19 @@ export default function QnaDetail() {
                     ))}
                 </Box>
 
+                <Typography variant="h6" gutterBottom sx={{ textIndent: '20px' }}>
+                    본문
+                </Typography>
                 <Typography variant="body1" paragraph sx={{ whiteSpace: 'pre-wrap', backgroundColor: '#f9f9f9', padding: 2, borderRadius: 1 }}>
                     {qnaData.content}
                 </Typography>
 
                 {qnaData.isAnswer && qnaData.answer && (
                     <>
-                        <Typography variant="h6" gutterBottom>
+                        <Typography variant="h6" gutterBottom sx={{ textIndent: '20px' }}>
                             답변
                         </Typography>
-                        <Typography variant="body1" sx={{ whiteSpace: 'pre-wrap', backgroundColor: '#f1f8e9', padding: 2, borderRadius: 1 }}>
+                        <Typography variant="body1" sx={{ whiteSpace: 'pre-wrap', backgroundColor: '#f0f8ff', padding: '15px 20px', borderRadius: '10px', border: '1px solid #b3d4fc' }}>
                             {qnaData.answer.content}
                         </Typography>
                         <Typography variant="body2" sx={{ textAlign: 'right', color: 'textSecondary', marginTop: 2 }}>
@@ -180,11 +183,13 @@ export default function QnaDetail() {
                 )}
             </Box>
             <Grid container spacing={2} sx={{ marginTop: '30px', justifyContent: 'flex-end' }}>
-                <Grid xs={3}>
-                    <Button variant="contained" size="large" fullWidth onClick={handleEdit}>
-                        수정
-                    </Button>
-                </Grid>
+                {!qnaData.isAnswer && (
+                    <Grid xs={3}>
+                        <Button variant="contained" size="large" fullWidth onClick={handleEdit}>
+                            수정
+                        </Button>
+                    </Grid>
+                )}
                 <Grid xs={3}>
                     <Button
                         variant="contained"

--- a/server/src/main/java/com/example/kakao_mlms/controller/AdminController.java
+++ b/server/src/main/java/com/example/kakao_mlms/controller/AdminController.java
@@ -4,6 +4,8 @@ import com.example.kakao_mlms.annotation.UserId;
 import com.example.kakao_mlms.domain.type.Category;
 import com.example.kakao_mlms.dto.response.QnaDtoResponse;
 import com.example.kakao_mlms.dto.UserDto;
+import com.example.kakao_mlms.dto.response.QnaDtoWithImagesResponse;
+import com.example.kakao_mlms.exception.ResponseDto;
 import com.example.kakao_mlms.service.AnswerService;
 import com.example.kakao_mlms.service.QnaService;
 import com.example.kakao_mlms.service.UserService;
@@ -15,6 +17,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.*;
 
 @Slf4j
@@ -46,9 +49,21 @@ public class AdminController {
         return ResponseEntity.ok(qnaResponse);
     }
 
-    @PostMapping("/qnas/{id}")
-    public ResponseEntity<Long> replyQna(@PathVariable("id") Long id, @RequestBody String content, @UserId Long userId) {
+    @GetMapping("/qnas/{qnaId}")
+    public ResponseEntity<?> getQna(@PathVariable("qnaId") Long qnaId) {
+        QnaDtoWithImagesResponse qnaWithImagesResponse =
+                QnaDtoWithImagesResponse.from(qnaService.getQnaWithImages(qnaId), answerService.getAnswer(qnaId));
+        return ResponseEntity.ok(qnaWithImagesResponse);
+    }
+
+    @PostMapping("/qnas/{qnaId}")
+    public ResponseEntity<Long> replyQna(@PathVariable("qnaId") Long id, @RequestBody String content, @UserId Long userId) {
         answerService.replyQna(userId, id, content);
         return ResponseEntity.status(HttpStatus.CREATED).body(id);
+    }
+
+    @DeleteMapping("/qnas/{qnaId}")
+    public ResponseDto<?> deleteQna(@UserId Long id, @PathVariable("qnaId") Long qnaId) {
+        return ResponseDto.ok(qnaService.deleteQna(id, qnaId));
     }
 }

--- a/server/src/main/java/com/example/kakao_mlms/controller/AdminController.java
+++ b/server/src/main/java/com/example/kakao_mlms/controller/AdminController.java
@@ -8,6 +8,7 @@ import com.example.kakao_mlms.service.AnswerService;
 import com.example.kakao_mlms.service.QnaService;
 import com.example.kakao_mlms.service.UserService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -16,6 +17,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+@Slf4j
 @RestController
 @RequestMapping("/api/v1/admins")
 @RequiredArgsConstructor
@@ -34,10 +36,12 @@ public class AdminController {
 
     @GetMapping("/qnas")
     public ResponseEntity<Page<QnaDtoResponse>> getAllQnas(
-            @RequestParam(required = false) String title,
-            @RequestParam(required = false) Category category,
-            @PageableDefault(size = 10, sort = "id", direction = Sort.Direction.ASC) Pageable pageable) {
-        Page<QnaDtoResponse> qnaResponse = qnaService.searchQnas(title, category, pageable)
+            @RequestParam(required = false, name = "notAnswered") Boolean notAnswered,
+            @RequestParam(required = false, name = "title") String title,
+            @RequestParam(required = false, name = "category") Category category,
+            @PageableDefault(size = 10, sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
+        log.info("notAnswered = {}, title = {}, category = {}, pageable = {}", notAnswered, title, category, pageable);
+        Page<QnaDtoResponse> qnaResponse = qnaService.searchQnas(title, category, notAnswered, pageable)
                 .map(QnaDtoResponse::from);
         return ResponseEntity.ok(qnaResponse);
     }

--- a/server/src/main/java/com/example/kakao_mlms/controller/AdminController.java
+++ b/server/src/main/java/com/example/kakao_mlms/controller/AdminController.java
@@ -2,6 +2,7 @@ package com.example.kakao_mlms.controller;
 
 import com.example.kakao_mlms.annotation.UserId;
 import com.example.kakao_mlms.domain.type.Category;
+import com.example.kakao_mlms.dto.response.AdminUserInfoDto;
 import com.example.kakao_mlms.dto.response.QnaDtoResponse;
 import com.example.kakao_mlms.dto.UserDto;
 import com.example.kakao_mlms.dto.response.QnaDtoWithImagesResponse;
@@ -30,11 +31,11 @@ public class AdminController {
     private final AnswerService answerService;
 
     @GetMapping("/users")
-    public ResponseEntity<Page<UserDto>> getAllUsers(
+    public ResponseEntity<Page<AdminUserInfoDto>> getAllUsers(
             @RequestParam(required = false, name = "name") String name,
-            @PageableDefault(size = 10, sort = "nickname", direction = Sort.Direction.ASC) Pageable pageable) {
-        Page<UserDto> users = userService.searchUsers(name, pageable);
-        return ResponseEntity.ok(users);
+            @PageableDefault(size = 10, sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
+        Page<AdminUserInfoDto> adminUserInfos = userService.searchUsers(name, pageable).map(AdminUserInfoDto::from);
+        return ResponseEntity.ok(adminUserInfos);
     }
 
     @GetMapping("/qnas")

--- a/server/src/main/java/com/example/kakao_mlms/controller/AuthController.java
+++ b/server/src/main/java/com/example/kakao_mlms/controller/AuthController.java
@@ -37,7 +37,7 @@ public class AuthController {
     }
 
     //사용자 정보 수정
-    @PatchMapping("/update")
+    @PostMapping("/update")
     public ResponseDto<?> updateUserInfo(@UserId Long id, @RequestBody UserResisterDto requestDto) {
         return ResponseDto.created(authService.updateUserInfo(id, requestDto));
     }

--- a/server/src/main/java/com/example/kakao_mlms/domain/Answer.java
+++ b/server/src/main/java/com/example/kakao_mlms/domain/Answer.java
@@ -28,11 +28,11 @@ public class Answer {
     @Column(name = "created_date", nullable = false, updatable = false)
     private LocalDateTime createdDate;
 
-    @ManyToOne(optional = false)
+    @OneToOne(optional = false)
     @JoinColumn(name = "qna_id", foreignKey = @ForeignKey(name = "fk_answer_qna_id"))
     private Qna qna;
 
-    @ManyToOne(optional = false)
+    @OneToOne(optional = false)
     @JoinColumn(name = "admin_id", foreignKey = @ForeignKey(name = "fk_answer_admin_id"))
     private User user;
 
@@ -54,5 +54,9 @@ public class Answer {
     @Override
     public int hashCode() {
         return Objects.hash(id, content, createdDate, qna, user);
+    }
+
+    public void update(String content) {
+        this.content = content;
     }
 }

--- a/server/src/main/java/com/example/kakao_mlms/domain/Qna.java
+++ b/server/src/main/java/com/example/kakao_mlms/domain/Qna.java
@@ -83,4 +83,8 @@ public class Qna {
         this.content = content;
         this.category = category;
     }
+
+    public void reply() {
+        this.isAnswer = true;
+    }
 }

--- a/server/src/main/java/com/example/kakao_mlms/dto/response/AdminUserInfoDto.java
+++ b/server/src/main/java/com/example/kakao_mlms/dto/response/AdminUserInfoDto.java
@@ -1,0 +1,26 @@
+package com.example.kakao_mlms.dto.response;
+
+import com.example.kakao_mlms.domain.type.EProvider;
+import com.example.kakao_mlms.domain.type.ERole;
+import com.example.kakao_mlms.dto.UserDto;
+
+import java.time.LocalDate;
+
+public record AdminUserInfoDto(Long id,
+                               String serialId,
+                               EProvider provider,
+                               ERole role,
+                               LocalDate createdDate,
+                               String nickname,
+                               Boolean isLogin
+) {
+    public static AdminUserInfoDto from(UserDto userDto) {
+        return new AdminUserInfoDto(userDto.id(),
+                userDto.serialId(),
+                userDto.provider(),
+                userDto.role(),
+                userDto.createdDate(),
+                userDto.nickname(),
+                userDto.isLogin());
+    }
+}

--- a/server/src/main/java/com/example/kakao_mlms/repository/AnswerRepository.java
+++ b/server/src/main/java/com/example/kakao_mlms/repository/AnswerRepository.java
@@ -7,4 +7,6 @@ import java.util.Optional;
 
 public interface AnswerRepository extends JpaRepository<Answer, Long> {
     Optional<Answer> findByQna_Id(Long qnaId);
+
+    void deleteByQna_Id(Long qnaId);
 }

--- a/server/src/main/java/com/example/kakao_mlms/repository/QnaRepository.java
+++ b/server/src/main/java/com/example/kakao_mlms/repository/QnaRepository.java
@@ -19,14 +19,23 @@ public interface QnaRepository extends JpaRepository<Qna, Long> {
     @Query("SELECT q FROM Qna q WHERE q.user.id = :userId AND q.category = :category AND LOWER(q.title) LIKE LOWER(CONCAT('%', :title, '%'))")
     Page<Qna> findByUserIdAndTitleAndCategory(@Param("userId") Long userId, @Param("title") String title, @Param("category") Category category, Pageable pageable);
 
+    @Query("SELECT q FROM Qna q WHERE q.isAnswer = :isAnswer AND q.category = :category AND LOWER(q.title) LIKE LOWER(CONCAT('%', :title, '%'))")
+    Page<Qna> findByIsAnswerAndTitleAndCategory(@Param("isAnswer") Boolean isAnswer, @Param("title") String title, @Param("category") Category category, Pageable pageable);
+
     @Query("SELECT q FROM Qna q WHERE q.user.id = :userId AND q.category = :category")
     Page<Qna> findByUserIdAndCategory(@Param("userId") Long userId, @Param("category") Category category, Pageable pageable);
+
+    @Query("SELECT q FROM Qna q WHERE q.isAnswer = :isAnswer AND q.category = :category")
+    Page<Qna> findByIsAnswerAndCategory(@Param("isAnswer") Boolean isAnswer, @Param("category") Category category, Pageable pageable);
 
     @Query("SELECT q FROM Qna q WHERE q.category = :category")
     Page<Qna> findByCategory(@Param("category") Category category, Pageable pageable);
 
     @Query("SELECT q FROM Qna q WHERE q.user.id = :userId AND LOWER(q.title) LIKE LOWER(CONCAT('%', :title, '%'))")
     Page<Qna> findByUserIdAndTitle(@Param("userId") Long userId, @Param("title") String title, Pageable pageable);
+
+    @Query("SELECT q FROM Qna q WHERE q.isAnswer = :isAnswer AND LOWER(q.title) LIKE LOWER(CONCAT('%', :title, '%'))")
+    Page<Qna> findByIsAnswerAndTitle(@Param("isAnswer") Boolean isAnswer, @Param("title") String title, Pageable pageable);
 
     @Query("SELECT q FROM Qna q WHERE q.category = :category AND LOWER(q.title) LIKE LOWER(CONCAT('%', :title, '%'))")
     Page<Qna> findByTitleAndCategory(@Param("title") String title, @Param("category") Category category, Pageable pageable);
@@ -37,6 +46,7 @@ public interface QnaRepository extends JpaRepository<Qna, Long> {
 
     Optional<Qna> findQnaById(Long id);
     Page<Qna> findByUserId(Long userId, Pageable pageable);
+    Page<Qna> findByIsAnswer(Boolean isAnswer, Pageable pageable);
     Optional<Qna> findQnaByTitle(String title);
     Optional<Qna> findQnaByIdAndUser(Long id, User user);
     Page<Qna> findQnaByTitleContaining(String title, Pageable pageable);

--- a/server/src/main/java/com/example/kakao_mlms/repository/UserRepository.java
+++ b/server/src/main/java/com/example/kakao_mlms/repository/UserRepository.java
@@ -19,7 +19,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
     @Query(value = "update User u set u.refreshToken = :refreshToken where u.id = :userId")
     void updateRefreshToken(@Param("userId") Long userId, @Param("refreshToken") String refreshToken);
 
-    Page<User> findByNicknameContaining(String nickname, Pageable pageable);
+    Page<User> findByNicknameContainingIgnoreCase(String nickname, Pageable pageable);
 
     Optional<User> findByIdAndProvider(Long userId, EProvider provider);
 

--- a/server/src/main/java/com/example/kakao_mlms/security/config/SecurityConfig.java
+++ b/server/src/main/java/com/example/kakao_mlms/security/config/SecurityConfig.java
@@ -92,7 +92,7 @@ public class SecurityConfig {
                                 .logoutUrl("/api/v1/logout")
                                 .addLogoutHandler(customSignOutProcessHandler)
                                 .logoutSuccessHandler(customSignOutResultHandler)
-                                .deleteCookies("JSESSIONID", "nickname", "accessToken", "refreshToken") // 쿠키 삭제 설정
+                                .deleteCookies("JSESSIONID", "nickname", "accessToken", "refreshToken", "role") // 쿠키 삭제 설정
                 )
 
                 //예외 처리 설정

--- a/server/src/main/java/com/example/kakao_mlms/security/config/SecurityConfig.java
+++ b/server/src/main/java/com/example/kakao_mlms/security/config/SecurityConfig.java
@@ -18,6 +18,7 @@ import com.example.kakao_mlms.security.service.CustomOAuth2UserService;
 import com.example.kakao_mlms.security.service.CustomUserDetailService;
 import com.example.kakao_mlms.util.JwtUtil;
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;

--- a/server/src/main/java/com/example/kakao_mlms/security/handler/signin/DefaultSignInSuccessHandler.java
+++ b/server/src/main/java/com/example/kakao_mlms/security/handler/signin/DefaultSignInSuccessHandler.java
@@ -1,6 +1,7 @@
 package com.example.kakao_mlms.security.handler.signin;
 
 import com.example.kakao_mlms.domain.User;
+import com.example.kakao_mlms.domain.type.ERole;
 import com.example.kakao_mlms.dto.response.JwtTokenDto;
 import com.example.kakao_mlms.repository.UserRepository;
 import com.example.kakao_mlms.security.CustomUserDetails;
@@ -41,6 +42,7 @@ public class DefaultSignInSuccessHandler implements AuthenticationSuccessHandler
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
 
         CustomUserDetails userPrincipal = (CustomUserDetails) authentication.getPrincipal();
+        ERole role = userPrincipal.getRole();
 
         // JWT Token 발급
 
@@ -59,10 +61,10 @@ public class DefaultSignInSuccessHandler implements AuthenticationSuccessHandler
             setSuccessAppResponse(response, jwtTokenDto);
         } else if (isMobile) {
             log.info("앱브라우저");
-            setSuccessWebResponse(response, jwtTokenDto, nickname);
+            setSuccessWebResponse(response, jwtTokenDto, nickname, role);
         } else {
             log.info("웹");
-            setSuccessWebResponse(response, jwtTokenDto, nickname);
+            setSuccessWebResponse(response, jwtTokenDto, nickname, role);
         }
     }
 
@@ -86,6 +88,7 @@ public class DefaultSignInSuccessHandler implements AuthenticationSuccessHandler
         CookieUtil.addSecureCookie(response, "refreshToken", tokenDto.getRefreshToken(), jwtUtil.getWebRefreshTokenExpirationSecond());
         CookieUtil.addCookie(response, "accessToken", tokenDto.getAccessToken());
         CookieUtil.addCookie(response, "nickname", nickname);
+        CookieUtil.addCookie(response, "role", eRole.getDisplayName());
 
         response.sendRedirect(LOGIN_URL);
     }

--- a/server/src/main/java/com/example/kakao_mlms/security/handler/signin/DefaultSignInSuccessHandler.java
+++ b/server/src/main/java/com/example/kakao_mlms/security/handler/signin/DefaultSignInSuccessHandler.java
@@ -90,6 +90,6 @@ public class DefaultSignInSuccessHandler implements AuthenticationSuccessHandler
         CookieUtil.addCookie(response, "nickname", nickname);
         CookieUtil.addCookie(response, "role", eRole.getDisplayName());
 
-        response.sendRedirect(LOGIN_URL);
+        response.getWriter().println("OK");
     }
 }

--- a/server/src/main/java/com/example/kakao_mlms/service/AnswerService.java
+++ b/server/src/main/java/com/example/kakao_mlms/service/AnswerService.java
@@ -29,12 +29,11 @@ public class AnswerService {
         User adminUser = userRepository.findById(adminId).orElseThrow(EntityNotFoundException::new);
         Qna qna = qnaRepository.findById(qnaId).orElseThrow(EntityNotFoundException::new);
 
-        Answer answer;
         if (qna.getIsAnswer()) {
             Answer oldAnswer = answerRepository.findByQna_Id(qnaId).orElseThrow();
             oldAnswer.update(content);
         } else{
-            answer = Answer.builder().content(content).qna(qna).user(adminUser).build();
+            Answer answer = Answer.builder().content(content).qna(qna).user(adminUser).build();
             answerRepository.save(answer);
             qna.reply();
         }

--- a/server/src/main/java/com/example/kakao_mlms/service/AnswerService.java
+++ b/server/src/main/java/com/example/kakao_mlms/service/AnswerService.java
@@ -29,9 +29,16 @@ public class AnswerService {
         User adminUser = userRepository.findById(adminId).orElseThrow(EntityNotFoundException::new);
         Qna qna = qnaRepository.findById(qnaId).orElseThrow(EntityNotFoundException::new);
 
-        Answer answer = Answer.builder().content(content).qna(qna).user(adminUser).build();
+        Answer answer;
+        if (qna.getIsAnswer()) {
+            Answer oldAnswer = answerRepository.findByQna_Id(qnaId).orElseThrow();
+            oldAnswer.update(content);
+        } else{
+            answer = Answer.builder().content(content).qna(qna).user(adminUser).build();
+            answerRepository.save(answer);
+            qna.reply();
+        }
 
-        answerRepository.save(answer);
     }
 
     public AnswerDto getAnswer(Long qnaId) {

--- a/server/src/main/java/com/example/kakao_mlms/service/QnaService.java
+++ b/server/src/main/java/com/example/kakao_mlms/service/QnaService.java
@@ -13,6 +13,7 @@ import com.example.kakao_mlms.dto.response.AllDto;
 import com.example.kakao_mlms.dto.response.QnaListDto;
 import com.example.kakao_mlms.exception.CommonException;
 import com.example.kakao_mlms.exception.ErrorCode;
+import com.example.kakao_mlms.repository.AnswerRepository;
 import com.example.kakao_mlms.repository.QnaRepository;
 import com.example.kakao_mlms.repository.UserRepository;
 import jakarta.persistence.EntityNotFoundException;
@@ -35,6 +36,7 @@ public class QnaService {
     private final QnaRepository qnaRepository;
     private final UserRepository userRepository;
     private final ImageService imageService;
+    private final AnswerRepository answerRepository;
 
     public void createQna(QnaDto qnaDto, List<ImageDto> imageDtos) {
         Qna qna = qnaDto.toEntity();
@@ -125,6 +127,7 @@ public class QnaService {
             qna = qnaRepository.findQnaById(qnaId)
                     .orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_QNA));
 
+        answerRepository.deleteByQna_Id(qnaId);
         qnaRepository.delete(qna);
 
         return Boolean.TRUE;

--- a/server/src/main/java/com/example/kakao_mlms/service/QnaService.java
+++ b/server/src/main/java/com/example/kakao_mlms/service/QnaService.java
@@ -131,11 +131,21 @@ public class QnaService {
     }
 
     @Transactional(readOnly = true)
-    public Page<QnaDto> searchQnas(String title, Category category, Pageable pageable) {
-        if (StringUtils.hasText(title)) {
-            return qnaRepository.findByTitleContainingAndCategory(title, category, pageable).map(QnaDto::from);
+    public Page<QnaDto> searchQnas(String title, Category category, Boolean notAnswered, Pageable pageable) {
+        if (notAnswered) {
+            if (Objects.isNull(category) && !StringUtils.hasText(title)) {
+                return qnaRepository.findByIsAnswer(false, pageable).map(QnaDto::from);
+            } else if (Objects.isNull(category)) {
+                return qnaRepository.findByIsAnswerAndTitle(false, title, pageable).map(QnaDto::from);
+            } else if (StringUtils.hasText(title)) {
+                return qnaRepository.findByIsAnswerAndTitleAndCategory(false, title, category, pageable).map(QnaDto::from);
+            } else {
+                return qnaRepository.findByIsAnswerAndCategory(false, category, pageable).map(QnaDto::from);
+            }
+        } else {
+            return getQnaDtos(title, category, pageable);
         }
-        return qnaRepository.findAll(pageable).map(QnaDto::from);
+
     }
 
     @Transactional(readOnly = true)
@@ -151,15 +161,19 @@ public class QnaService {
                 return qnaRepository.findByUserIdAndCategory(userId, category, pageable).map(QnaDto::from);
             }
         } else {
-            if (Objects.isNull(category) && !StringUtils.hasText(title)) {
-                return qnaRepository.findAll(pageable).map(QnaDto::from);
-            } else if (Objects.isNull(category)) {
-                return qnaRepository.findByTitle(title, pageable).map(QnaDto::from);
-            } else if (StringUtils.hasText(title)) {
-                return qnaRepository.findByTitleAndCategory(title, category, pageable).map(QnaDto::from);
-            } else {
-                return qnaRepository.findByCategory(category, pageable).map(QnaDto::from);
-            }
+            return getQnaDtos(title, category, pageable);
+        }
+    }
+
+    private Page<QnaDto> getQnaDtos(String title, Category category, Pageable pageable) {
+        if (Objects.isNull(category) && !StringUtils.hasText(title)) {
+            return qnaRepository.findAll(pageable).map(QnaDto::from);
+        } else if (Objects.isNull(category)) {
+            return qnaRepository.findByTitle(title, pageable).map(QnaDto::from);
+        } else if (StringUtils.hasText(title)) {
+            return qnaRepository.findByTitleAndCategory(title, category, pageable).map(QnaDto::from);
+        } else {
+            return qnaRepository.findByCategory(category, pageable).map(QnaDto::from);
         }
     }
 

--- a/server/src/main/java/com/example/kakao_mlms/service/UserService.java
+++ b/server/src/main/java/com/example/kakao_mlms/service/UserService.java
@@ -21,7 +21,7 @@ public class UserService {
     @Transactional(readOnly = true)
     public Page<UserDto> searchUsers(String name, Pageable pageable) {
         if(StringUtils.hasText(name)) {
-            return userRepository.findByNicknameContaining(name, pageable).map(UserDto::from);
+            return userRepository.findByNicknameContainingIgnoreCase(name, pageable).map(UserDto::from);
         }
         return userRepository.findAll(pageable).map(UserDto::from);
     }


### PR DESCRIPTION
## #️⃣연관된 이슈


## 📝작업 내용

- 마이페이지에서 내 정보 수정 기능 구현 및 백엔드 연동
- 어드민 QNA 리스트 페이지 구현 및 백엔드 연동
- 어드민 QNA 상세보기 페이지 구현 및 백엔드 연동
- 어드민 USER 관리 페이지 구현 및 백엔드 연동
- 답변하기 기능 추가 및 답변 수정하기 기능 추가
- 이미 답변이 달린 게시물은 회원이 삭제 못하도록 구현
- 일반 로그인 성공 시 서버 리디렉션 방식이 아닌 클라이언트 리디렉션 방식으로 변경
- 유효성 검사 실패 시 알람이 아닌 에러 메시지 형식으로 변경

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

- 일반 로그인 성공 시 DefaultSignInSuccessHandler 에서 리디렉션을 직접 처리하는 방식으로 구현되어 있었는데
서버에서 로그인 성공 후 직접 리디렉션을 시켜주면 ACAO 헤더의 값이 와일드 카드로 변환 되는데 이 부분이 ACAC 헤더와 충돌을 일으켜서 서버에서는 바디에 응답을 주고 클라이언트에서 리디렉션을 하는 방식으로 변경
